### PR TITLE
[Feat] 챌린지 피드 승인시 workoutLog 자동 생성

### DIFF
--- a/backend/demo/src/main/java/store/oneul/mvc/config/DbConfig.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/config/DbConfig.java
@@ -4,7 +4,7 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@MapperScan(basePackages = { "store.oneul.mvc.user.dao", "store.oneul.mvc.challenge.dao", "store.oneul.mvc.feed.dao", "store.oneul.mvc.chat.dao" })
+@MapperScan(basePackages = { "store.oneul.mvc.user.dao", "store.oneul.mvc.challenge.dao", "store.oneul.mvc.feed.dao", "store.oneul.mvc.chat.dao", "store.oneul.mvc.workoutLog.dao" })
 public class DbConfig {
 
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/feed/controller/FeedController.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/feed/controller/FeedController.java
@@ -56,10 +56,16 @@ public class FeedController {
     }
     
     @PatchMapping("/{id}/checks")
-    public ResponseEntity<FeedDTO> evaluateFeed(@PathVariable Long challengeId, @PathVariable Long id, @RequestBody FeedEvaluationRequest feedEvaluationRequest) {
+    public ResponseEntity<FeedDTO> evaluateFeed(
+    		@PathVariable Long challengeId, 
+    		@PathVariable Long id, 
+    		@RequestBody FeedEvaluationRequest feedEvaluationRequest,
+    		@AuthenticationPrincipal UserDTO user
+    ) {
     	feedEvaluationRequest.setChallengeId(challengeId);
     	feedEvaluationRequest.setId(id);
-    	feedService.evaluateFeed(feedEvaluationRequest);
+    	Long userId = user.getUserId();
+    	feedService.evaluateFeed(feedEvaluationRequest, userId);
     	FeedDTO feedDTO = feedService.getFeed(challengeId, feedEvaluationRequest.getId());
     	return ResponseEntity.ok(feedDTO);
     }

--- a/backend/demo/src/main/java/store/oneul/mvc/feed/service/FeedService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/feed/service/FeedService.java
@@ -16,5 +16,5 @@ public interface FeedService {
 
     public List<FeedDTO> getFeeds(Long challengeId);
     
-    public void evaluateFeed(FeedEvaluationRequest feedEvaluationRequest);
+    public void evaluateFeed(FeedEvaluationRequest feedEvaluationRequest, Long userId);
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/feed/service/FeedServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/feed/service/FeedServiceImpl.java
@@ -8,11 +8,14 @@ import lombok.RequiredArgsConstructor;
 import store.oneul.mvc.feed.dao.FeedDAO;
 import store.oneul.mvc.feed.dto.FeedDTO;
 import store.oneul.mvc.feed.dto.FeedEvaluationRequest;
+import store.oneul.mvc.workoutLog.dao.WorkoutLogDAO;
+import store.oneul.mvc.workoutLog.dto.WorkoutLogInsertRequestDTO;
 
 @Service
 @RequiredArgsConstructor
 public class FeedServiceImpl implements FeedService {
     private final FeedDAO feedDAO;
+    private final WorkoutLogDAO workoutLogDAO;
 
     @Override
     public void createFeed(Long challengeId, FeedDTO feedDTO) {
@@ -40,8 +43,15 @@ public class FeedServiceImpl implements FeedService {
     }
 
 	@Override
-	public void evaluateFeed(FeedEvaluationRequest feedEvaluationRequest) {
+	public void evaluateFeed(FeedEvaluationRequest feedEvaluationRequest, Long userId) {
 		feedDAO.evaluateFeed(feedEvaluationRequest);
+		if("APPROVED".equals(feedEvaluationRequest.getCheckStatus())) {
+			WorkoutLogInsertRequestDTO workoutLogRequest = new WorkoutLogInsertRequestDTO();
+			workoutLogRequest.setChallengeId(feedEvaluationRequest.getChallengeId());
+			workoutLogRequest.setFeedId(feedEvaluationRequest.getId());
+			workoutLogRequest.setUserId(userId);
+			workoutLogDAO.insertWorkoutLog(workoutLogRequest);
+		}
 	}
 
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/feed/service/FeedServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/feed/service/FeedServiceImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import store.oneul.mvc.feed.dao.FeedDAO;
 import store.oneul.mvc.feed.dto.FeedDTO;
 import store.oneul.mvc.feed.dto.FeedEvaluationRequest;
+import store.oneul.mvc.feed.enums.CheckStatus;
 import store.oneul.mvc.workoutLog.dao.WorkoutLogDAO;
 import store.oneul.mvc.workoutLog.dto.WorkoutLogInsertRequestDTO;
 
@@ -45,7 +46,7 @@ public class FeedServiceImpl implements FeedService {
 	@Override
 	public void evaluateFeed(FeedEvaluationRequest feedEvaluationRequest, Long userId) {
 		feedDAO.evaluateFeed(feedEvaluationRequest);
-		if("APPROVED".equals(feedEvaluationRequest.getCheckStatus())) {
+		if(CheckStatus.APPROVED == feedEvaluationRequest.getCheckStatus()) {
 			WorkoutLogInsertRequestDTO workoutLogRequest = new WorkoutLogInsertRequestDTO();
 			workoutLogRequest.setChallengeId(feedEvaluationRequest.getChallengeId());
 			workoutLogRequest.setFeedId(feedEvaluationRequest.getId());

--- a/backend/demo/src/main/java/store/oneul/mvc/workoutLog/dao/WorkoutLogDAO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/workoutLog/dao/WorkoutLogDAO.java
@@ -1,0 +1,11 @@
+package store.oneul.mvc.workoutLog.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import store.oneul.mvc.workoutLog.dto.WorkoutLogDTO;
+import store.oneul.mvc.workoutLog.dto.WorkoutLogInsertRequestDTO;
+
+@Mapper
+public interface WorkoutLogDAO {
+	WorkoutLogDTO insertWorkoutLog(WorkoutLogInsertRequestDTO workoutLogInsertRequestDto);
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/workoutLog/dao/WorkoutLogDAO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/workoutLog/dao/WorkoutLogDAO.java
@@ -7,5 +7,5 @@ import store.oneul.mvc.workoutLog.dto.WorkoutLogInsertRequestDTO;
 
 @Mapper
 public interface WorkoutLogDAO {
-	WorkoutLogDTO insertWorkoutLog(WorkoutLogInsertRequestDTO workoutLogInsertRequestDto);
+	void insertWorkoutLog(WorkoutLogInsertRequestDTO workoutLogInsertRequestDto);
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/workoutLog/dto/WorkoutLogDTO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/workoutLog/dto/WorkoutLogDTO.java
@@ -16,7 +16,6 @@ public class WorkoutLogDTO {
 	private Long userId;
 	private Long challengeId;
 	private Long feedId;
-	private String comment;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/workoutLog/dto/WorkoutLogDTO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/workoutLog/dto/WorkoutLogDTO.java
@@ -1,0 +1,22 @@
+package store.oneul.mvc.workoutLog.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data        
+@Builder     
+@NoArgsConstructor 
+@AllArgsConstructor
+public class WorkoutLogDTO {
+	private Long id;
+	private Long userId;
+	private Long challengeId;
+	private Long feedId;
+	private String comment;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/workoutLog/dto/WorkoutLogInsertRequestDTO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/workoutLog/dto/WorkoutLogInsertRequestDTO.java
@@ -1,0 +1,17 @@
+package store.oneul.mvc.workoutLog.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data        
+@Builder     
+@NoArgsConstructor 
+@AllArgsConstructor
+public class WorkoutLogInsertRequestDTO {
+	private Long userId;
+	private Long challengeId;
+	private Long feedId;
+	private String comment;
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/workoutLog/dto/WorkoutLogInsertRequestDTO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/workoutLog/dto/WorkoutLogInsertRequestDTO.java
@@ -13,5 +13,4 @@ public class WorkoutLogInsertRequestDTO {
 	private Long userId;
 	private Long challengeId;
 	private Long feedId;
-	private String comment;
 }

--- a/backend/demo/src/main/resources/mappers/WorkoutLogMapper.xml
+++ b/backend/demo/src/main/resources/mappers/WorkoutLogMapper.xml
@@ -9,7 +9,7 @@
 	<insert id="insertWorkoutLog" parameterType="WorkoutLogInsertRequestDTO">
 		INSERT IGNORE INTO workout_log (user_id, challenge_id, feed_id)
 		VALUES (
-			#{userId}, #{challengeId}, #{feedId}}
+			#{userId}, #{challengeId}, #{feedId}
 		);
 	</insert>
 	

--- a/backend/demo/src/main/resources/mappers/WorkoutLogMapper.xml
+++ b/backend/demo/src/main/resources/mappers/WorkoutLogMapper.xml
@@ -7,9 +7,9 @@
 
 	<!-- INSERT -->
 	<insert id="insertWorkoutLog" parameterType="WorkoutLogInsertRequestDTO">
-		INSERT IGNORE INTO workout_log (user_id, challenge_id, feed_id, comment)
+		INSERT IGNORE INTO workout_log (user_id, challenge_id, feed_id)
 		VALUES (
-			#{userId}, #{challengeId}, #{feedId}, #{comment}
+			#{userId}, #{challengeId}, #{feedId}}
 		);
 	</insert>
 	

--- a/backend/demo/src/main/resources/mappers/WorkoutLogMapper.xml
+++ b/backend/demo/src/main/resources/mappers/WorkoutLogMapper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="store.oneul.mvc.workoutLog.dao.WorkoutLogDAO">
+
+	<!-- INSERT -->
+	<insert id="insertWorkoutLog" parameterType="WorkoutLogInsertRequestDTO">
+		INSERT IGNORE INTO workout_log (user_id, challenge_id, feed_id, comment)
+		VALUES (
+			#{userId}, #{challengeId}, #{feedId}, #{comment}
+		);
+	</insert>
+	
+</mapper>

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -4,6 +4,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
   withCredentials: true, // 쿠키 인증 등에 필요
+  headers: { "Content-Type": "application/json" },
 });
 
 // 요청 인터셉터 (토큰 자동 주입)
@@ -59,7 +60,7 @@ export const patch = async <T>(
   body?: any,
   config?: AxiosRequestConfig,
 ): Promise<T> => {
-  const res: AxiosResponse<T> = await api.put(url, body, config);
+  const res: AxiosResponse<T> = await api.patch(url, body, config);
   return res.data;
 };
 


### PR DESCRIPTION
## 개요

Resolves: #106 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정

## 작업 내용

- api 훅 수정 (patch 훅이 put으로 구동되고 있던 부분, header content-type 추가)
- workoutLogDTO, workoutLogInsertRequestDTO, workoutLogMapper 구현 (자동 생성 부분만)
- feedService 단에서 피드 승인 내용이 APPROVED일 경우 workoutLog 자동 생성 로직 호출 

