### PR TITLE
[Feat] feed api 연결, primary color 추가 

### DIFF
--- a/backend/demo/src/main/java/store/oneul/mvc/feed/dto/FeedDTO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/feed/dto/FeedDTO.java
@@ -17,6 +17,7 @@ import store.oneul.mvc.feed.enums.CheckStatus;
 public class FeedDTO {
     private Long id;
     private Long userId;
+    private String nickname;
     private Long challengeId;
     private String imageUrl;
     private String content;

--- a/backend/demo/src/main/resources/mappers/FeedMapper.xml
+++ b/backend/demo/src/main/resources/mappers/FeedMapper.xml
@@ -7,15 +7,22 @@
 
     <!-- SELECT ONE -->
     <select id="getFeed" parameterType="map" resultType="FeedDTO">
-        SELECT * FROM feed
-        WHERE challenge_id = #{challengeId} AND id = #{id}
+        SELECT f.*, u.nickname 
+        FROM feed f
+        LEFT JOIN user u
+          ON f.user_id = u.user.id
+        WHERE f.challenge_id = #{challengeId} 
+          AND f.id = #{id}
     </select>
 
     <!-- SELECT ALL -->
     <select id="getFeeds" parameterType="map" resultType="FeedDTO">
-        SELECT * FROM feed
-        WHERE challenge_id = #{challengeId}
-        ORDER BY created_at DESC
+        SELECT f.*, u.nickname 
+        FROM feed f
+        LEFT JOIN user u
+          ON f.user_id = u.user_id
+        WHERE f.challenge_id = #{challengeId}
+        ORDER BY f.created_at DESC
     </select>
 
     <!-- INSERT -->

--- a/frontend/src/components/challengeDetail/ChallengeDetailPage.tsx
+++ b/frontend/src/components/challengeDetail/ChallengeDetailPage.tsx
@@ -32,14 +32,13 @@ function ChallengeDetailPage() {
   }
 
   return (
-    <div className="relative flex min-h-screen select-none flex-col overflow-hidden bg-gradient-to-bl from-[#21414F] via-[#10212B] to-[#17171C]">
+    <div className="relative flex min-h-screen select-none flex-col overflow-hidden bg-[#0E0E11]">
       {/* 챌린지 상세 정보 영역 */}
       <section className="flex flex-col items-center justify-center px-6 py-12">
         <h1 className="mb-6 text-2xl font-bold text-white">
           챌린지 상세 페이지 - {challengeId}
         </h1>
         <div className="w-7xl mx-auto flex gap-6 text-white">
-          <ChallengeFeed />
           <div className="min-w-sm flex flex-col gap-8">
             {challenge ? (
               <>
@@ -54,6 +53,7 @@ function ChallengeDetailPage() {
               <p>데이터를 불러오는데 실패했습니다.</p>
             )}
           </div>
+          <ChallengeFeed />
         </div>
       </section>
     </div>

--- a/frontend/src/components/challengeDetail/ChallengeDetailPage.tsx
+++ b/frontend/src/components/challengeDetail/ChallengeDetailPage.tsx
@@ -6,14 +6,14 @@ import { useChallenge } from "@/hooks/useChallenge";
 
 function ChallengeDetailPage() {
   const { challengeId } = useParams<{ challengeId: string }>();
-  if (!challengeId) return <p>잘못된 경로입니다.</p>;
-
   const {
     data: challenge,
     isLoading,
     isError,
     error,
-  } = useChallenge(challengeId);
+  } = useChallenge(challengeId ?? "");
+
+  if (!challengeId) return <p>잘못된 경로입니다.</p>;
 
   // 로딩 또는 에러시
   if (isLoading) {

--- a/frontend/src/components/challengeDetail/ChallengeDetailPage.tsx
+++ b/frontend/src/components/challengeDetail/ChallengeDetailPage.tsx
@@ -41,12 +41,18 @@ function ChallengeDetailPage() {
         <div className="w-7xl mx-auto flex gap-6 text-white">
           <ChallengeFeed />
           <div className="min-w-sm flex flex-col gap-8">
-            <ChallengeDetail data={challenge!} />
-            <ChallengeStatus
-              success={challenge!.successDay}
-              goal={challenge!.goalDay}
-              endDate={challenge!.endDate}
-            />
+            {challenge ? (
+              <>
+                <ChallengeDetail data={challenge} />
+                <ChallengeStatus
+                  success={challenge.successDay}
+                  goal={challenge.goalDay}
+                  endDate={challenge.endDate}
+                />
+              </>
+            ) : (
+              <p>데이터를 불러오는데 실패했습니다.</p>
+            )}
           </div>
         </div>
       </section>

--- a/frontend/src/components/challengeDetail/ChallengeFeed.tsx
+++ b/frontend/src/components/challengeDetail/ChallengeFeed.tsx
@@ -56,7 +56,7 @@ function ChallengeFeed() {
   const closeAll = () => setModalState(null);
 
   return (
-    <section className="flex w-full flex-col gap-3 rounded-2xl border border-[#2d2d2d] bg-[#1A1A1F] px-8 py-9">
+    <section className="flex w-full flex-col gap-3 rounded-2xl bg-[#1A1A1F] px-8 py-9">
       <div className="flex items-center gap-4">
         <span className="text-center text-xl font-semibold text-gray-200">
           챌린지 피드

--- a/frontend/src/components/challengeDetail/ChallengeStatus.tsx
+++ b/frontend/src/components/challengeDetail/ChallengeStatus.tsx
@@ -10,19 +10,19 @@ function ChallengeStatus({ success, endDate, goal }: ChallengeStatusProps) {
       (new Date(endDate).getTime() - Date.now()) / (1000 * 60 * 60 * 24),
     ) + 1;
   return (
-    <div className="flex flex-col gap-6 rounded-2xl border border-[#2d2d2d] bg-[#1A1A1F] px-8 py-9">
+    <div className="flex flex-col gap-6 rounded-2xl bg-[#1A1A1F] px-8 py-9">
       <h4 className="text-lg text-gray-200">나의 달성 현황</h4>
       <div className="flex flex-col gap-6 leading-7 text-gray-400">
         <p>
           챌린지 시작일로부터 지금까지
           <br />
-          <span className="text-point font-medium">
+          <span className="text-primary-purple-100 font-medium">
             총 {success}일, 100% 달성 중
           </span>
         </p>
         <p>
           챌린지 종료일까지 {elapsedDays > 0 ? elapsedDays : 0}일 중<br />
-          <span className="text-point font-medium">
+          <span className="text-primary-purple-100 font-medium">
             {goal - success}일 남았어요!
           </span>
         </p>

--- a/frontend/src/components/challengeDetail/ChellengeDetail.tsx
+++ b/frontend/src/components/challengeDetail/ChellengeDetail.tsx
@@ -27,7 +27,7 @@ function ChallengeDetail({ data }: ChallengeDetailProps) {
     name,
   } = data;
   return (
-    <section className="flex flex-col gap-8 rounded-2xl border border-[#2d2d2d] bg-[#1A1A1F] px-8 py-9">
+    <section className="flex flex-col gap-8 rounded-2xl bg-[#1A1A1F] px-8 py-9">
       {/* 상단 뱃지 + 제목 */}
       <div className="flex items-center gap-2">
         <Badge type={isChallenge ? "challenge" : "normal"}>

--- a/frontend/src/components/feed/FeedDetailModal.tsx
+++ b/frontend/src/components/feed/FeedDetailModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { CheckInLog } from "../challengeDetail/ChallengeFeed";
 import { formatTimeAgo } from "@/utils/date";
+import { Feed } from "@/types/Feed";
 
 function FeedDetailModal({
   isOpen,
@@ -9,10 +9,10 @@ function FeedDetailModal({
 }: {
   isOpen: boolean;
   onClose: () => void;
-  feed: CheckInLog;
+  feed: Feed;
 }) {
   const [showAnimation, setShowAnimation] = useState(false);
-  const [likeCount, setLikeCount] = useState(feed.like_count);
+  const [likeCount, setLikeCount] = useState(feed.likeCount);
   const [liked, setLiked] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -59,7 +59,7 @@ function FeedDetailModal({
         }}
       >
         <div className="flex items-center justify-between">
-          <span className="font-bold">{feed.user_id}</span>
+          <span className="font-bold">{feed.userId}</span>
           <button
             onClick={onClose}
             className="cursor-pointer text-gray-400 hover:text-gray-200"
@@ -68,9 +68,9 @@ function FeedDetailModal({
           </button>
         </div>
         <div className="max-h-[400px] overflow-y-auto">
-          {feed.image_url && (
+          {feed.imageUrl && (
             <img
-              src={feed.image_url}
+              src={feed.imageUrl}
               alt="Feed"
               className="mb-4 h-64 w-full rounded-lg object-cover"
             />
@@ -85,7 +85,7 @@ function FeedDetailModal({
 
         <div className="flex items-center justify-between">
           <span className="text-sm text-gray-400">
-            {formatTimeAgo(feed.created_at)}
+            {formatTimeAgo(feed.createdAt)}
           </span>
           <button
             onClick={handleLike}

--- a/frontend/src/components/feed/FeedUpdateModal.tsx
+++ b/frontend/src/components/feed/FeedUpdateModal.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from "react";
-import { CheckInLog } from "../challengeDetail/ChallengeFeed";
+import { Feed } from "@/types/Feed";
 
 interface FeedUpdateModalProps {
   isOpen: boolean;
   onClose: () => void;
-  initialData: CheckInLog;
+  initialData: Feed;
 }
 
 function FeedUpdateModal({
@@ -20,7 +20,7 @@ function FeedUpdateModal({
 
   useEffect(() => {
     if (isOpen) {
-      setPreviewUrl(initialData.image_url);
+      setPreviewUrl(initialData.imageUrl);
       setContent(initialData.content);
       setImageFile(null);
       setTimeout(() => setShowAnimation(true), 10);
@@ -38,7 +38,7 @@ function FeedUpdateModal({
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] ?? null;
     setImageFile(file);
-    setPreviewUrl(file ? URL.createObjectURL(file) : initialData.image_url);
+    setPreviewUrl(file ? URL.createObjectURL(file) : initialData.imageUrl);
   };
 
   const handleUpdate = async () => {

--- a/frontend/src/components/feed/MateFeedItem.tsx
+++ b/frontend/src/components/feed/MateFeedItem.tsx
@@ -1,27 +1,27 @@
 import { formatTimeAgo } from "@/utils/date";
-import { CheckInLog } from "../challengeDetail/ChallengeFeed";
+import { Feed } from "@/types/Feed";
 
 export interface MateFeedItemProps {
-  log: CheckInLog;
+  feed: Feed;
   onClick?: () => void;
 }
 
-function MateFeedItem({ log, onClick }: MateFeedItemProps) {
+function MateFeedItem({ feed, onClick }: MateFeedItemProps) {
   return (
     <li onClick={onClick} className="group">
       <a href="#" className="flex items-center gap-4">
         <img
           className="w-26 h-20 rounded-sm"
-          src={log.image_url}
+          src={feed.imageUrl}
           alt="오늘 챌린지메이트 인증"
         />
         <div className="flex h-[76px] w-[130px] flex-1 flex-col justify-between">
           <div className="line-clamp-2 font-normal text-gray-400 group-hover:text-gray-300">
-            {log.content}
+            {feed.content}
           </div>
           <div className="flex justify-between gap-4 text-sm">
-            <div className="text-gray-500">{log.user_id}</div>
-            <div className="text-gray-500">{formatTimeAgo(log.created_at)}</div>
+            <div className="text-gray-500">{feed.nickname}</div>
+            <div className="text-gray-500">{formatTimeAgo(feed.createdAt)}</div>
           </div>
         </div>
       </a>

--- a/frontend/src/components/feed/MateFeedList.tsx
+++ b/frontend/src/components/feed/MateFeedList.tsx
@@ -1,19 +1,19 @@
-import { CheckInLog } from "../challengeDetail/ChallengeFeed";
+import { Feed } from "@/types/Feed";
 import MateFeedItem from "./MateFeedItem";
 
 interface MateFeedListProps {
-  logs: CheckInLog[];
-  onItemClick?: (log: CheckInLog) => void;
+  feeds: Feed[];
+  onItemClick?: (feed: Feed) => void;
 }
 
-function MateFeedList({ logs, onItemClick }: MateFeedListProps) {
+function MateFeedList({ feeds, onItemClick }: MateFeedListProps) {
   return (
     <ul className="h-full space-y-4 overflow-y-auto pr-5">
-      {logs.map((log) => (
+      {feeds.map((feed) => (
         <MateFeedItem
-          key={log.id}
-          log={log}
-          onClick={() => onItemClick?.(log)}
+          key={feed.id}
+          feed={feed}
+          onClick={() => onItemClick?.(feed)}
         />
       ))}
     </ul>

--- a/frontend/src/components/feed/MyFeedCard.tsx
+++ b/frontend/src/components/feed/MyFeedCard.tsx
@@ -1,16 +1,16 @@
 import { formatTimeAgo } from "@/utils/date";
-import { CheckInLog } from "../challengeDetail/ChallengeFeed";
 import CheckStatus from "../common/CheckStatus";
+import { Feed } from "@/types/Feed";
 
 interface MyFeedCardProps {
-  log: CheckInLog | null;
+  feed: Feed | null;
   onCreate?: () => void;
-  onEdit?: (log: CheckInLog) => void;
-  onDetail?: (log: CheckInLog) => void;
+  onEdit?: (feed: Feed) => void;
+  onDetail?: (feed: Feed) => void;
 }
 
-function MyFeedCard({ log, onCreate, onEdit, onDetail }: MyFeedCardProps) {
-  if (!log) {
+function MyFeedCard({ feed, onCreate, onEdit, onDetail }: MyFeedCardProps) {
+  if (!feed) {
     return (
       <>
         <p className="mb-4 text-gray-400">
@@ -29,14 +29,14 @@ function MyFeedCard({ log, onCreate, onEdit, onDetail }: MyFeedCardProps) {
   return (
     <div
       className="flex max-w-md cursor-pointer flex-col"
-      onClick={() => onDetail?.(log)}
+      onClick={() => onDetail?.(feed)}
     >
       <div className="mb-3 flex items-start justify-between">
         <p className="font-medium text-gray-400">오늘의 인증 완료 💪🔥</p>
         <button
           onClick={(e) => {
             e.stopPropagation();
-            onEdit?.(log);
+            onEdit?.(feed);
           }}
           className="cursor-pointer p-1 text-gray-500 hover:text-gray-200"
           aria-label="인증 수정"
@@ -60,19 +60,19 @@ function MyFeedCard({ log, onCreate, onEdit, onDetail }: MyFeedCardProps) {
 
       <div className="relative mb-3 aspect-square w-full overflow-hidden rounded-lg bg-[#24242c]">
         <img
-          src={log.image_url}
+          src={feed.imageUrl}
           alt="내 오늘 인증 사진"
           className="h-full w-full object-cover"
         />
         {/* 상태 뱃지 추가 */}
         <div className="absolute right-2 top-2">
-          <CheckStatus type={log.check_status} />
+          <CheckStatus type={feed.checkStatus} />
         </div>
       </div>
 
-      <p className="line-clamp-2 text-gray-500">{log.content}</p>
+      <p className="line-clamp-2 text-gray-500">{feed.content}</p>
       <span className="text-right text-sm text-gray-600">
-        {formatTimeAgo(log.created_at)}
+        {formatTimeAgo(feed.createdAt)}
       </span>
     </div>
   );

--- a/frontend/src/components/feedCheck/FeedCheckItem.tsx
+++ b/frontend/src/components/feedCheck/FeedCheckItem.tsx
@@ -25,7 +25,7 @@ function FeedCheckItem({ feed, onClick }: MateFeedItemProps) {
             {feed.content}
           </div>
           <div className="flex justify-between gap-4 text-sm">
-            <div className="text-gray-500">{feed.userId}</div>
+            <div className="text-gray-500">{feed.nickname}</div>
             <div className="text-gray-500">{formatTimeAgo(feed.createdAt)}</div>
           </div>
         </div>

--- a/frontend/src/components/feedCheck/FeedCheckItem.tsx
+++ b/frontend/src/components/feedCheck/FeedCheckItem.tsx
@@ -1,13 +1,13 @@
 import { formatTimeAgo } from "@/utils/date";
-import { CheckInLog } from "../challengeDetail/ChallengeFeed";
 import CheckStatus from "../common/CheckStatus";
+import { Feed } from "@/types/Feed";
 
 export interface MateFeedItemProps {
-  log: CheckInLog;
+  feed: Feed;
   onClick?: () => void;
 }
 
-function FeedCheckItem({ log, onClick }: MateFeedItemProps) {
+function FeedCheckItem({ feed, onClick }: MateFeedItemProps) {
   return (
     <li
       onClick={onClick}
@@ -16,17 +16,17 @@ function FeedCheckItem({ log, onClick }: MateFeedItemProps) {
       <a href="#" className="flex items-center gap-4">
         <img
           className="w-26 h-20 rounded-sm"
-          src={log.image_url}
+          src={feed.imageUrl}
           alt="챌린지메이트 인증"
         />
         <div className="flex h-[76px] w-[130px] flex-1 flex-col items-baseline justify-between">
-          <CheckStatus type={log.check_status} />
+          <CheckStatus type={feed.checkStatus} />
           <div className="line-clamp-1 text-sm font-normal text-gray-400">
-            {log.content}
+            {feed.content}
           </div>
           <div className="flex justify-between gap-4 text-sm">
-            <div className="text-gray-500">{log.user_id}</div>
-            <div className="text-gray-500">{formatTimeAgo(log.created_at)}</div>
+            <div className="text-gray-500">{feed.userId}</div>
+            <div className="text-gray-500">{formatTimeAgo(feed.createdAt)}</div>
           </div>
         </div>
       </a>

--- a/frontend/src/components/feedCheck/FeedCheckList.tsx
+++ b/frontend/src/components/feedCheck/FeedCheckList.tsx
@@ -1,11 +1,11 @@
-import { CheckInLog } from "../challengeDetail/ChallengeFeed";
+import { Feed } from "@/types/Feed";
 import FeedCheckItem from "./FeedCheckItem";
 
 interface FeedCheckListProps {
-  onLogSelect: (log: CheckInLog) => void;
+  onFeedSelect: (feed: Feed) => void;
 }
 
-const mockData: CheckInLog[] = [
+const mockData: Feed[] = [
   {
     id: 1,
     user_id: 201,
@@ -41,14 +41,14 @@ const mockData: CheckInLog[] = [
   },
 ];
 
-function FeedCheckList({ onLogSelect }: FeedCheckListProps) {
+function FeedCheckList({ onFeedSelect }: FeedCheckListProps) {
   return (
     <div className="flex-1 space-y-4 overflow-y-auto px-4 py-6">
       {mockData.map((item) => (
         <FeedCheckItem
           key={item.id}
-          log={item}
-          onClick={() => onLogSelect(item)}
+          feed={item}
+          onClick={() => onFeedSelect(item)}
         />
       ))}
     </div>

--- a/frontend/src/components/feedCheck/FeedCheckList.tsx
+++ b/frontend/src/components/feedCheck/FeedCheckList.tsx
@@ -1,56 +1,29 @@
 import { Feed } from "@/types/Feed";
 import FeedCheckItem from "./FeedCheckItem";
+import { useChallengeFeeds } from "@/hooks/useFeed";
+import { useParams } from "react-router";
 
 interface FeedCheckListProps {
   onFeedSelect: (feed: Feed) => void;
 }
 
-const mockData: Feed[] = [
-  {
-    id: 1,
-    user_id: 201,
-    challenge_id: 5,
-    image_url: "https://picsum.photos/seed/1/200/200",
-    content: "오운완입니다~^^ 오늘도 화이팅!",
-    like_count: 3,
-    created_at: "2025-05-01T00:00:00.000Z",
-    check_status: "PENDING",
-    checked_at: null,
-  },
-  {
-    id: 2,
-    user_id: 202,
-    challenge_id: 5,
-    image_url: "https://picsum.photos/seed/2/200/200",
-    content: "스포애니에서 쇠질완료~ 뿌듯하네요 💪",
-    like_count: 5,
-    created_at: "2025-05-02T00:00:00.000Z",
-    check_status: "APPROVED",
-    checked_at: "2025-05-02T01:00:00.000Z",
-  },
-  {
-    id: 3,
-    user_id: 203,
-    challenge_id: 5,
-    image_url: "https://picsum.photos/seed/3/200/200",
-    content: "운동하다 회전근개 파열… 다들 조심하세요 😭",
-    like_count: 1,
-    created_at: "2025-05-03T00:00:00.000Z",
-    check_status: "REJECTED",
-    checked_at: "2025-05-03T02:00:00.000Z",
-  },
-];
-
 function FeedCheckList({ onFeedSelect }: FeedCheckListProps) {
+  const { challengeId } = useParams<{ challengeId: string }>();
+  const { data } = useChallengeFeeds(challengeId ?? "");
+
   return (
     <div className="flex-1 space-y-4 overflow-y-auto px-4 py-6">
-      {mockData.map((item) => (
-        <FeedCheckItem
-          key={item.id}
-          feed={item}
-          onClick={() => onFeedSelect(item)}
-        />
-      ))}
+      {data ? (
+        data.map((item) => (
+          <FeedCheckItem
+            key={item.id}
+            feed={item}
+            onClick={() => onFeedSelect(item)}
+          />
+        ))
+      ) : (
+        <p>피드 내역이 존재하지 않습니다.</p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/feedCheck/FeedCheckModal.tsx
+++ b/frontend/src/components/feedCheck/FeedCheckModal.tsx
@@ -1,31 +1,31 @@
+import { Feed } from "@/types/Feed";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { CheckInLog } from "../challengeDetail/ChallengeFeed";
 
 function FeedCheckModal({
   isOpen,
   onClose,
-  log,
+  feed,
 }: {
   isOpen: boolean;
   onClose: () => void;
-  log: CheckInLog;
+  feed: Feed;
 }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showAnimation, setShowAnimation] = useState(false);
-  const [selectedStatus, setSelectedStatus] = useState<
-    CheckInLog["check_status"]
-  >(log.check_status);
+  const [selectedStatus, setSelectedStatus] = useState<Feed["checkStatus"]>(
+    feed.checkStatus,
+  );
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (isOpen) {
-      setSelectedStatus(log.check_status);
+      setSelectedStatus(feed.checkStatus);
       setTimeout(() => setShowAnimation(true), 10);
     } else {
       setShowAnimation(false);
     }
-  }, [isOpen, log.check_status]);
+  }, [isOpen, feed.checkStatus]);
 
   const handleBackgroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
@@ -81,7 +81,7 @@ function FeedCheckModal({
       >
         {/* 헤더 */}
         <div className="flex items-center justify-between">
-          <span className="font-bold">{log.user_id}</span>
+          <span className="font-bold">{feed.userId}</span>
           <button
             onClick={onClose}
             className="cursor-pointer text-gray-400 hover:text-gray-200"
@@ -92,16 +92,16 @@ function FeedCheckModal({
 
         {/* 이미지 & 내용 */}
         <div className="max-h-[400px] overflow-y-auto">
-          {log.image_url && (
+          {feed.imageUrl && (
             <img
-              src={log.image_url}
+              src={feed.imageUrl}
               alt="Feed"
               className="mb-4 h-64 w-full rounded-lg object-cover"
             />
           )}
-          <p className="mb-4 whitespace-normal break-words">{log.content}</p>
+          <p className="mb-4 whitespace-normal break-words">{feed.content}</p>
           <span className="text-sm text-gray-400">
-            {formatTimeAgo(log.created_at)}
+            {formatTimeAgo(feed.created_at)}
           </span>
         </div>
 
@@ -110,7 +110,7 @@ function FeedCheckModal({
           <select
             value={selectedStatus}
             onChange={(e) =>
-              setSelectedStatus(e.target.value as CheckInLog["check_status"])
+              setSelectedStatus(e.target.value as Feed["checkStatus"])
             }
             className="focus:border-point w-32 rounded-lg border border-gray-700 bg-[#2A2A2D] px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none"
           >

--- a/frontend/src/components/feedCheck/FeedCheckModal.tsx
+++ b/frontend/src/components/feedCheck/FeedCheckModal.tsx
@@ -81,7 +81,7 @@ function FeedCheckModal({
       >
         {/* 헤더 */}
         <div className="flex items-center justify-between">
-          <span className="font-bold">{feed.userId}</span>
+          <span className="font-bold">{feed.nickname}</span>
           <button
             onClick={onClose}
             className="cursor-pointer text-gray-400 hover:text-gray-200"
@@ -101,7 +101,7 @@ function FeedCheckModal({
           )}
           <p className="mb-4 whitespace-normal break-words">{feed.content}</p>
           <span className="text-sm text-gray-400">
-            {formatTimeAgo(feed.created_at)}
+            {formatTimeAgo(feed.createdAt)}
           </span>
         </div>
 

--- a/frontend/src/components/feedCheck/FeedCheckTab.tsx
+++ b/frontend/src/components/feedCheck/FeedCheckTab.tsx
@@ -1,26 +1,24 @@
 import { useState } from "react";
 import FeedCheckModal from "./FeedCheckModal";
-import { CheckInLog } from "../challengeDetail/ChallengeFeed";
 import FeedCheckHeader from "./FeedCheckHeader";
 import FeedCheckList from "./FeedCheckList";
+import { Feed } from "@/types/Feed";
 
 export default function FeedCheckTab() {
-  // 목업 데이터 (나중에 API에서 받아온 데이터로 교체)
-
-  const [selected, setSelected] = useState<CheckInLog | null>(null);
+  const [selected, setSelected] = useState<Feed | null>(null);
 
   return (
     <div className="flex flex-1 flex-col">
       <FeedCheckHeader />
       {/* 리스트 */}
-      <FeedCheckList onLogSelect={setSelected} />
+      <FeedCheckList onFeedSelect={setSelected} />
 
       {/* 모달 */}
       {selected && (
         <FeedCheckModal
           isOpen={true}
           onClose={() => setSelected(null)}
-          log={selected}
+          feed={selected}
         />
       )}
     </div>

--- a/frontend/src/components/home/MyWorkoutDashboard.tsx
+++ b/frontend/src/components/home/MyWorkoutDashboard.tsx
@@ -1,4 +1,3 @@
-import { CheckInLog } from "@/components/challengeDetail/ChallengeFeed";
 import MyFeedCard from "@/components/feed/MyFeedCard";
 import CommunityFeed from "@/components/home/CommunityFeed";
 import { feedData } from "@/constants/homeConstants";
@@ -7,6 +6,7 @@ import { useState } from "react";
 import MonthlyStats from "./MonthlyStats";
 import StreakCalendar from "./StreakCalendar";
 import WorkoutModal from "./WorkoutModal";
+import { Feed } from "@/types/Feed";
 
 export const getContributionColor = (count: number) => {
   if (count >= 4) return "bg-[#8B5CF6]"; // 진한 보라색
@@ -28,7 +28,7 @@ const MyWorkoutDashboard = () => {
   const [currentYear, setCurrentYear] = useState<number>(
     new Date().getFullYear(),
   );
-  const [todayLog, setTodayLog] = useState<CheckInLog | null>(null);
+  const [todayFeed, setTodayFeed] = useState<Feed | null>(null);
 
   const feedCountByMonth = Array(12).fill(0);
   Object.keys(feedData).forEach((date) => {
@@ -48,19 +48,19 @@ const MyWorkoutDashboard = () => {
     contributionsByDate[date] = feeds.length;
   });
 
-  const handleCreateLog = () => {
+  const handleCreateFeed = () => {
     // TODO: 인증 생성 로직 구현
     window.location.href = "/challenge/create";
   };
 
-  const handleEditLog = (log: CheckInLog) => {
+  const handleEditFeed = (feed: Feed) => {
     // TODO: 인증 수정 로직 구현
-    console.log("Edit log:", log);
+    console.log("Edit feed:", feed);
   };
 
-  const handleDetailLog = (log: CheckInLog) => {
+  const handleDetailFeed = (feed: Feed) => {
     // TODO: 인증 상세 보기 로직 구현
-    console.log("View log details:", log);
+    console.log("View feed details:", feed);
   };
 
   return (
@@ -71,10 +71,10 @@ const MyWorkoutDashboard = () => {
         <div className="w-1/3 rounded-lg bg-[#1A1A1E] p-6">
           <h2 className="mb-6 text-xl font-semibold text-white">오늘의 인증</h2>
           <MyFeedCard
-            log={todayLog}
-            onCreate={handleCreateLog}
-            onEdit={handleEditLog}
-            onDetail={handleDetailLog}
+            feed={todayFeed}
+            onCreate={handleCreateFeed}
+            onEdit={handleEditFeed}
+            onDetail={handleDetailFeed}
           />
         </div>
         <div className="w-2/3 rounded-lg bg-[#1A1A1E] p-6">

--- a/frontend/src/hooks/useChallenge.ts
+++ b/frontend/src/hooks/useChallenge.ts
@@ -7,6 +7,10 @@ export function useChallenge(challengeId: string) {
   return useGet<Challenge>(
     ["challenge", challengeId],
     `/challenges/${challengeId}`,
-    { staleTime: 1000 * 60 * 10, gcTime: 1000 * 60 * 30 },
+    {
+      staleTime: 1000 * 60 * 10,
+      gcTime: 1000 * 60 * 30,
+      enabled: Boolean(challengeId),
+    },
   );
 }

--- a/frontend/src/hooks/useChallenge.ts
+++ b/frontend/src/hooks/useChallenge.ts
@@ -7,6 +7,6 @@ export function useChallenge(challengeId: string) {
   return useGet<Challenge>(
     ["challenge", challengeId],
     `/challenges/${challengeId}`,
-    { staleTime: 1000 * 60 * 5 },
+    { staleTime: 1000 * 60 * 10, gcTime: 1000 * 60 * 30 },
   );
 }

--- a/frontend/src/hooks/useFeed.ts
+++ b/frontend/src/hooks/useFeed.ts
@@ -1,0 +1,10 @@
+import { Feed } from "@/types/Feed";
+import { useGet } from "./useApiHooks";
+
+export function useChallengeFeeds(challengeId: string) {
+  return useGet<Feed[]>(
+    ["feeds", challengeId],
+    `/challenges/${challengeId}/feeds`,
+    { staleTime: 1000 * 60 * 1, gcTime: 1000 * 60 * 5 },
+  );
+}

--- a/frontend/src/hooks/useFeed.ts
+++ b/frontend/src/hooks/useFeed.ts
@@ -5,6 +5,10 @@ export function useChallengeFeeds(challengeId: string) {
   return useGet<Feed[]>(
     ["feeds", challengeId],
     `/challenges/${challengeId}/feeds`,
-    { staleTime: 1000 * 60 * 1, gcTime: 1000 * 60 * 5 },
+    {
+      staleTime: 1000 * 60 * 1,
+      gcTime: 1000 * 60 * 5,
+      enabled: Boolean(challengeId),
+    },
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -25,6 +25,10 @@ html,
   --color-gray-1: #2c2c35;
   --color-logo-white: #eae7e6;
   --color-black-chat: #101014;
+  --color-primary-purple-100: #a78bfa;
+  --color-primary-purple-200: #8b5cf6;
+  --color-primary-purple-300: #7c3aed;
+  --color-primary-purple-400: #6d28d9;
 }
 
 /* Chrome, Safari, Edge */

--- a/frontend/src/types/Feed.ts
+++ b/frontend/src/types/Feed.ts
@@ -1,0 +1,15 @@
+export type CheckStatus = "PENDING" | "APPROVED" | "REJECTED";
+
+export interface Feed {
+  id: number;
+  userId: number;
+  nickname: string;
+  challengeId: number;
+  imageUrl: string;
+  content: string;
+  likeCount: number;
+  createdAt: string;
+  updatedAt: string;
+  checkStatus: CheckStatus;
+  checkedAt: string | null;
+}


### PR DESCRIPTION
## 개요

Resolves: #65
Resolves: #69
Resolves: #133 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)

## 작업 내용

- 피드 리스트, 피드 체크 리스트 항목에 대한 api 연결 
- 피드 리스트 get 요청을 위한 훅 생성 
- 피드, 챌린지 요청 훅의 staleTime, gcTime 추가 및 조정 
- Feed 타입 생성 및 기존 CheckInLog 인터페이스 삭제
- CheckInLog 인터페이스를 사용하는 기존 코드를 Feed로 교체, 명확한 네이밍을 위한 변수명 수정 (log -> feed) 
- FeedDTO에 nickname 항목 추가
- FeedDTO 관련 select query에 user nickname 조인 
- 디테일 페이지 레이아웃 변경
- 테일윈드 primary-purple 색상 설정 추가 (Home 컴포넌트 내부에 구현된 색상 참고, 100~400)

## 스크린샷

![image](https://github.com/user-attachments/assets/317bc61d-c81c-45ab-9c2c-14ff2f20335c)

