### PR TITLE
[Feat] 챌린지 디테일 모달 구현 

### DIFF
--- a/backend/demo/src/main/resources/mappers/ChallengeMapper.xml
+++ b/backend/demo/src/main/resources/mappers/ChallengeMapper.xml
@@ -94,7 +94,11 @@
     </select>
     
     <select id="getCommunityChallenges" resultType="ChallengeDTO">
-        SELECT * FROM challenge
+        SELECT 
+        	c.*, 
+        	u.nickname AS owner_nickname
+         FROM challenge c
+         JOIN user u ON c.owner_id = u.user_id
         WHERE is_public = 1
         ORDER BY created_at DESC
     </select>

--- a/backend/demo/src/main/resources/mappers/ChallengeMapper.xml
+++ b/backend/demo/src/main/resources/mappers/ChallengeMapper.xml
@@ -41,7 +41,11 @@
 
     <!-- SELECT ALL -->
     <select id="getChallenges" resultType="ChallengeDTO">
-        SELECT * FROM challenge
+        SELECT 
+        	c.*, 
+        	u.nickname AS owner_nickname
+         FROM challenge c
+         JOIN user u ON c.owner_id = u.user_id
         ORDER BY created_at DESC
     </select>
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,13 +12,14 @@ import { useEffect } from "react";
 import { data, Route, Routes } from "react-router";
 import "./App.css";
 import "./chart";
-import { Challenge } from "./api/challenge";
+
 import { get } from "./api/api";
 import { useQuery } from "@tanstack/react-query";
 import { useChallengeStore } from "@/stores/challengeStore";
 import { useFeedStore } from "@/stores/feedStore";
 import { Feed } from "@/types/Feed";
 import { Streak } from "@/types/Streak";
+import { Challenge } from "./types/Challenge";
 
 function App() {
   const { connect, disconnect } = useSocketStore();

--- a/frontend/src/components/challenge/ChallengeList.tsx
+++ b/frontend/src/components/challenge/ChallengeList.tsx
@@ -1,7 +1,7 @@
-import { Challenge } from "@/api/challenge";
 import { get } from "@/api/api";
 import { useQuery } from "@tanstack/react-query";
 import { useChallengeStore } from "@/stores/challengeStore";
+import { Challenge } from "@/types/Challenge";
 
 function ChallengeList() {
   const { data, isLoading, error } = useQuery<Challenge[]>({

--- a/frontend/src/components/challengeDetail/ChellengeDetail.tsx
+++ b/frontend/src/components/challengeDetail/ChellengeDetail.tsx
@@ -22,7 +22,7 @@ function ChallengeDetail({ data }: ChallengeDetailProps) {
     description,
     goalDay,
     totalDay,
-    isChallenge,
+    challenge,
     ownerNickname,
     name,
   } = data;
@@ -30,8 +30,8 @@ function ChallengeDetail({ data }: ChallengeDetailProps) {
     <section className="flex flex-col gap-8 rounded-2xl bg-[#1A1A1F] px-8 py-9">
       {/* 상단 뱃지 + 제목 */}
       <div className="flex items-center gap-2">
-        <Badge type={isChallenge ? "challenge" : "normal"}>
-          {isChallenge ? "챌린지" : "일반"}
+        <Badge type={challenge ? "challenge" : "normal"}>
+          {challenge ? "챌린지" : "일반"}
         </Badge>
         <div className="mt-1 flex items-center gap-2">
           <h3 className="text-xl font-bold text-gray-200">{name}</h3>

--- a/frontend/src/components/challengeRegist/ChallengeDetailModal.tsx
+++ b/frontend/src/components/challengeRegist/ChallengeDetailModal.tsx
@@ -1,0 +1,144 @@
+// components/ChallengeDetailModal.tsx
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { formatTimeHHMM } from "@/utils/date";
+import { Challenge } from "@/types/Challenge";
+import Badge from "../common/Badge";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  challenge: Challenge;
+}
+
+export default function ChallengeDetailModal({
+  isOpen,
+  onClose,
+  challenge,
+}: Props) {
+  const navigate = useNavigate();
+  const [showAnimation, setShowAnimation] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => setShowAnimation(true), 10);
+    } else {
+      setShowAnimation(false);
+    }
+  }, [isOpen]);
+
+  const handleBackgroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+      onClose();
+    }
+  };
+
+  const handleJoin = async () => {
+    if (challenge.entryFee > 0) {
+      // 유료 챌린지 → 결제 페이지로 이동
+      navigate(`/challenges/${challenge.challengeId}/order`);
+    } else {
+      // 무료 챌린지 → 즉시 신청 API 호출
+      try {
+        await fetch(`/api/challenges/${challenge.challengeId}/join`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        });
+        onClose();
+        // TODO: 성공 토스트, 리스트 리패치 등 추가
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      onClick={handleBackgroundClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <div
+        ref={modalRef}
+        className={`flex w-[400px] transform flex-col gap-4 rounded-2xl bg-[#1B1B1E] p-8 text-white transition-all duration-300 ${
+          showAnimation ? "scale-100 opacity-100" : "scale-90 opacity-0"
+        }`}
+        style={{
+          boxShadow:
+            "0 0 20px rgba(255, 255, 255, 0.1), 0 0 10px rgba(255, 255, 255, 0.2)",
+        }}
+      >
+        {/* 헤더 */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Badge type={challenge.challenge ? "challenge" : "normal"}>
+              {challenge.challenge ? "챌린지" : "일반"}
+            </Badge>
+            <h2 className="text-xl font-semibold">{challenge.name}</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-200"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* 본문 */}
+        <div className="max-h-[400px] space-y-2 overflow-y-auto">
+          <div className="text-sm text-gray-400">
+            챌린지 매니저: {challenge.ownerNickname}
+          </div>
+
+          <div className="text-sm text-gray-400">
+            기간: {challenge.startDate.split("T")[0]}{" "}
+            {challenge.startDate.includes("T") && (
+              <span>{formatTimeHHMM(challenge.startDate)}</span>
+            )}{" "}
+            ~ {challenge.endDate.split("T")[0]}{" "}
+            {challenge.endDate.includes("T") && (
+              <span>{formatTimeHHMM(challenge.endDate)}</span>
+            )}
+          </div>
+
+          <div className="text-sm text-gray-400">
+            목표: {challenge.successDay ?? 0}일 달성 / 총 {challenge.totalDay}일
+          </div>
+          <div className="text-sm text-gray-400">
+            설명: {challenge.description}
+          </div>
+
+          <div className="text-sm text-gray-400">
+            참가비:{" "}
+            {challenge.entryFee > 0
+              ? `${challenge.entryFee.toLocaleString()}원`
+              : "무료"}
+          </div>
+
+          <p className="mt-4 whitespace-pre-wrap text-gray-100">
+            {challenge.description}
+          </p>
+        </div>
+
+        {/* 푸터 */}
+        <div className="mt-4 flex justify-end">
+          <button
+            onClick={handleJoin}
+            disabled={challenge.challengeStatus !== "RECRUITING"}
+            className={`rounded-md px-4 py-2 text-sm font-semibold transition ${
+              challenge.challengeStatus === "RECRUITING"
+                ? "bg-primary-purple-200 text-white hover:opacity-90"
+                : "cursor-not-allowed bg-gray-600 text-gray-300"
+            }`}
+          >
+            {challenge.challengeStatus === "RECRUITING"
+              ? "참여하기"
+              : "모집 종료"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/challengeRegist/ChallengeDetailModal.tsx
+++ b/frontend/src/components/challengeRegist/ChallengeDetailModal.tsx
@@ -62,7 +62,7 @@ export default function ChallengeDetailModal({
     >
       <div
         ref={modalRef}
-        className={`flex w-[400px] transform flex-col gap-4 rounded-2xl bg-[#1B1B1E] p-8 text-white transition-all duration-300 ${
+        className={`flex w-[400px] transform flex-col gap-8 rounded-2xl bg-[#1B1B1E] p-8 text-white transition-all duration-300 ${
           showAnimation ? "scale-100 opacity-100" : "scale-90 opacity-0"
         }`}
         style={{
@@ -107,23 +107,18 @@ export default function ChallengeDetailModal({
             목표: {challenge.successDay ?? 0}일 달성 / 총 {challenge.totalDay}일
           </div>
           <div className="text-sm text-gray-400">
-            설명: {challenge.description}
-          </div>
-
-          <div className="text-sm text-gray-400">
             참가비:{" "}
             {challenge.entryFee > 0
               ? `${challenge.entryFee.toLocaleString()}원`
               : "무료"}
           </div>
-
-          <p className="mt-4 whitespace-pre-wrap text-gray-100">
+          <p className="mt-6 whitespace-pre-wrap text-sm text-gray-300">
             {challenge.description}
           </p>
         </div>
 
         {/* 푸터 */}
-        <div className="mt-4 flex justify-end">
+        <div className="flex justify-end">
           <button
             onClick={handleJoin}
             disabled={challenge.challengeStatus !== "RECRUITING"}

--- a/frontend/src/components/challengeSearch/ChallengeSearchPage.tsx
+++ b/frontend/src/components/challengeSearch/ChallengeSearchPage.tsx
@@ -5,13 +5,18 @@ import Badge from "../common/Badge";
 import { categories, tabs } from "@/constants/challengeSearchContants";
 import { useChallengeStore } from "@/stores/challengeStore";
 import { Challenge } from "@/types/Challenge";
+import ChallengeDetailModal from "../challengeRegist/ChallengeDetailModal";
 
 const ChallengeSearchPage = () => {
   const [activeTab, setActiveTab] = useState("전체");
   const [activeCategory, setActiveCategory] = useState<String | null>(null);
   const [keyword, setKeyword] = useState("");
+  const [selected, setSelected] = useState<Challenge | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const challengeList = useChallengeStore.getState().communityChallengeList;
+  const challengeList = useChallengeStore(
+    (state) => state.communityChallengeList,
+  );
 
   const filteredList = challengeList.filter((c) => {
     const matchTab =
@@ -90,7 +95,11 @@ const ChallengeSearchPage = () => {
             {filteredList.map((room) => (
               <div
                 key={room.challengeId}
-                className="rounded-lg border border-[#2F2F33] bg-[#222227] p-5 shadow-sm transition hover:shadow-md"
+                className="cursor-pointer rounded-lg border border-[#2F2F33] bg-[#222227] p-5 shadow-sm transition hover:shadow-md"
+                onClick={() => {
+                  setSelected(room);
+                  setIsModalOpen(true);
+                }}
               >
                 <div className="mb-2 flex items-center justify-between">
                   <h3 className="line-clamp-1 text-base font-semibold text-white">
@@ -116,6 +125,14 @@ const ChallengeSearchPage = () => {
             )}
           </div>
         </div>
+        {/* 모달 삽입 */}
+        {selected && (
+          <ChallengeDetailModal
+            isOpen={isModalOpen}
+            onClose={() => setIsModalOpen(false)}
+            challenge={selected}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/challengeSearch/ChallengeSearchPage.tsx
+++ b/frontend/src/components/challengeSearch/ChallengeSearchPage.tsx
@@ -1,15 +1,15 @@
 // pages/ChallengeSearchPage.tsx
 import { useState } from "react";
 import { FiSearch } from "react-icons/fi";
-import Badge from "../common/Badge";
+import Badge from "@components/common/Badge";
 import { categories, tabs } from "@/constants/challengeSearchContants";
 import { useChallengeStore } from "@/stores/challengeStore";
 import { Challenge } from "@/types/Challenge";
-import ChallengeDetailModal from "../challengeRegist/ChallengeDetailModal";
+import ChallengeDetailModal from "@components/challengeRegist/ChallengeDetailModal";
 
 const ChallengeSearchPage = () => {
   const [activeTab, setActiveTab] = useState("전체");
-  const [activeCategory, setActiveCategory] = useState<String | null>(null);
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [keyword, setKeyword] = useState("");
   const [selected, setSelected] = useState<Challenge | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/frontend/src/stores/challengeStore.tsx
+++ b/frontend/src/stores/challengeStore.tsx
@@ -1,4 +1,4 @@
-import { Challenge } from "@/api/challenge";
+import { Challenge } from "@/types/Challenge";
 import { create } from "zustand";
 
 interface ChallengeStore {

--- a/frontend/src/types/Challenge.ts
+++ b/frontend/src/types/Challenge.ts
@@ -13,8 +13,9 @@ export interface Challenge {
   challenge: boolean;
   public: boolean;
   createdAt: string;
-  successDay: number; // 삭제 예정
+  successDay?: number; // 삭제 예정
   roomPassword: string; // 삭제 예정
   memberCount: number;
   challengeStatus: string;
+  participantCount?: number;
 }


### PR DESCRIPTION
## 개요

Resolves: #145 #146 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)

## 작업 내용

- 기존 작업물에서 `/api/Challenge.ts` 경로로 임포트하여 사용하는 `Challenge` 타입 경로를 `@/types/Challenge.ts`로 수정 
- 챌린지 리스트 목록 아이템을 클릭하면 해당 챌린지 디테일을 보여주는 챌린지 디테일 모달 컴포넌트 생성 
- 챌린지 상태가 모집중이면 참여 버튼 활성화, 아닐 경우 비활성화 
- 무료 챌린지일 경우 참여 버튼 클릭시 챌린지 참여 api 요청 / 유료 챌린지일 경우 클릭시 결제 페이지로 이동 

## 스크린샷

![challengeDetail](https://github.com/user-attachments/assets/962a596c-205f-4cc8-b0ab-8483a6d6ddb7)
