### PR TITLE
[Feat] 게스트 로그인 기능 추가 및 시큐리티 설정 반영

### DIFF
--- a/backend/demo/src/main/java/store/oneul/mvc/challenge/dao/ChallengeDAO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/challenge/dao/ChallengeDAO.java
@@ -24,4 +24,6 @@ public interface ChallengeDAO {
 
     List<ChallengeDTO> getCommunityChallenges();
 
+	ChallengeDTO getChallengeById(Long challengeId);
+
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/challenge/service/ChallengeService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/challenge/service/ChallengeService.java
@@ -19,5 +19,10 @@ public interface ChallengeService {
     public List<ChallengeDTO> getSubscribedChallenges(Long userId);
 
     public List<ChallengeDTO> getCommunityChallenges();
+    
+    public ChallengeDTO getChallenge(Long challengeId);
+
+    
+    
 
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/challenge/service/ChallengeServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/challenge/service/ChallengeServiceImpl.java
@@ -49,4 +49,9 @@ public class ChallengeServiceImpl implements ChallengeService {
         return challengeDAO.getCommunityChallenges();
     }
 
+    @Override
+    public ChallengeDTO getChallenge(Long challengeId) {
+        return challengeDAO.getChallengeById(challengeId);
+    }
+
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/config/RedisConfig.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/config/RedisConfig.java
@@ -9,6 +9,7 @@ import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -45,6 +46,18 @@ public class RedisConfig {
 
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+    
+    // 추가: JSON 직렬화용 RedisTemplate
+    @Bean(name = "jsonRedisTemplate")
+    public RedisTemplate<String, Object> jsonRedisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return template;
     }

--- a/backend/demo/src/main/java/store/oneul/mvc/config/SecurityConfig.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
             .and()
             .csrf().disable()
             .authorizeHttpRequests(auth -> auth
+            	.requestMatchers("/api/users/guest-login/**").permitAll()
                 .requestMatchers("/api/feeds/community").permitAll()
                 .requestMatchers("/api/**").authenticated()
                 .anyRequest().permitAll()

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/controller/PaymentController.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/controller/PaymentController.java
@@ -1,0 +1,77 @@
+package store.oneul.mvc.payment.controller;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import store.oneul.mvc.challenge.dto.ChallengeDTO;
+import store.oneul.mvc.challenge.service.ChallengeService;
+import store.oneul.mvc.common.exception.InvalidParameterException;
+import store.oneul.mvc.common.exception.NotFoundException;
+import store.oneul.mvc.payment.dto.OrderIdResponse;
+import store.oneul.mvc.payment.dto.PaymentSessionDto;
+import store.oneul.mvc.user.dto.UserDTO;
+
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private static final int PAYMENT_SESSION_TTL_MINUTES = 15; // Redis TTL
+
+    private final ChallengeService challengeService;
+
+    @Qualifier("jsonRedisTemplate")
+    private final RedisTemplate<String, Object> jsonRedisTemplate;
+
+    @GetMapping("/order/{challengeId}")
+    public ResponseEntity<OrderIdResponse> getOrderId(
+            @PathVariable Long challengeId,
+            @AuthenticationPrincipal UserDTO loginUser
+    ) {
+        Long userId = loginUser.getUserId();
+
+        // 1. 챌린지 유효성 검증
+        ChallengeDTO challenge = challengeService.getChallenge(challengeId);
+        if (challenge == null) {
+            throw new NotFoundException("챌린지를 찾을 수 없습니다.");
+        }
+
+        LocalDate today = LocalDate.now();
+
+        if (challenge.getStartDate() != null && !today.isBefore(challenge.getStartDate())) {
+            throw new InvalidParameterException("이미 시작된 챌린지는 참가할 수 없습니다.");
+        }
+
+        // 2. Redis 조회
+        String redisKey = "payment:session:user:" + userId;
+        PaymentSessionDto session = (PaymentSessionDto) jsonRedisTemplate.opsForValue().get(redisKey);
+
+        if (session != null) {
+            return ResponseEntity.ok(new OrderIdResponse(session.getOrderId(), session.getAmount()));
+        }
+
+        // 3. orderId 생성
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        String orderId = "user" + userId + ":challenge" + challengeId + ":" + timestamp;
+
+        // 4. Redis 저장
+        PaymentSessionDto newSession = new PaymentSessionDto(orderId, challengeId, challenge.getEntryFee());
+        jsonRedisTemplate.opsForValue().set(redisKey, newSession, Duration.ofMinutes(PAYMENT_SESSION_TTL_MINUTES));
+
+        // 5. 응답 반환
+        return ResponseEntity.ok(new OrderIdResponse(orderId, challenge.getEntryFee()));
+    }
+}
+

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dto/OrderIdResponse.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dto/OrderIdResponse.java
@@ -1,0 +1,15 @@
+package store.oneul.mvc.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderIdResponse {
+    private String orderId;
+    private int amount;
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dto/PaymentSessionDto.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dto/PaymentSessionDto.java
@@ -1,0 +1,16 @@
+package store.oneul.mvc.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentSessionDto {
+    private String orderId;
+    private Long challengeId;
+    private int amount;
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/user/controller/UserController.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/user/controller/UserController.java
@@ -1,20 +1,23 @@
 package store.oneul.mvc.user.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-
-import store.oneul.mvc.user.dto.UserDTO;
-import store.oneul.mvc.user.service.UserService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import store.oneul.mvc.security.jwt.JwtProvider;
+import store.oneul.mvc.security.rtr.RefreshTokenService;
+import store.oneul.mvc.user.dto.UserDTO;
+import store.oneul.mvc.user.service.UserService;
 
 @RestController
 @RequestMapping("/api/users")
@@ -22,6 +25,9 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 	
     private final UserService userService;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenService refreshTokenService;
+
 	
     @GetMapping("/me")
     public ResponseEntity<UserDTO> getMyInfo(@AuthenticationPrincipal UserDTO user) {
@@ -37,6 +43,32 @@ public class UserController {
         user.setUsername(input.getUsername());
         userService.updateUserInfo(user);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/guest-login/{guestNo}")
+    public ResponseEntity<?> guestLogin(@PathVariable int guestNo) {
+
+        String email = "guest" + guestNo + "@oneul.store";
+        UserDTO guest = userService.findByEmail(email);
+        if (guest == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                 .body("❌ 해당 게스트 계정이 존재하지 않습니다");
+        }
+
+        Map<String, Object> claims = Map.of(
+            "userId", guest.getUserId(),
+            "username", guest.getUsername(),
+            "nickname", guest.getNickname(),
+            "isGuest", true
+        );
+
+        String accessToken = jwtProvider.createToken(guest.getUserId(), claims);
+        String refreshToken = refreshTokenService.createAndSaveRefreshToken(guest.getUserId()); // ✅ 추가
+
+        return ResponseEntity.ok(Map.of(
+            "accessToken", accessToken,
+            "refreshToken", refreshToken
+        ));
     }
 
 }

--- a/backend/demo/src/main/resources/mappers/ChallengeMapper.xml
+++ b/backend/demo/src/main/resources/mappers/ChallengeMapper.xml
@@ -94,5 +94,10 @@
         WHERE is_public = 1
         ORDER BY created_at DESC
     </select>
+    
+	<select id="getChallengeById" resultType="ChallengeDTO">
+	  SELECT * FROM challenge WHERE challenge_id = #{challengeId}
+	</select>
+	    
 
 </mapper>


### PR DESCRIPTION
## 개요

Resolves: #160

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

- `/api/users/guest-login/{guestNo}` API 추가
- JWT accessToken + refreshToken 발급 구조 유지
- `UserController`에 `RefreshTokenService` 의존성 주입
- `SecurityConfig`에 해당 경로 permitAll 처리
- JWT 인증 및 재발급 필터 정상 작동 확인


## 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 공유사항 to 리뷰어
- 게스트 로그인은 `/api/users/guest-login/1` 또는 `/guest-login/2`로만 접근 가능하도록 제한할 예정
- `guestNo` 값은 내부적으로 `"guest" + guestNo + "@oneul.store"` 형식의 이메일로 변환되어 DB에서 해당 유저를 조회하는 용도로 사용
- 따라서 guest1@oneul.store, guest2@oneul.store 이메일을 가진 계정이 DB에 사전에 등록되어 있어야 정상 작동 => SQL반영완료
- 이후 필요한 경우 게스트 번호 및 개수는 추가 확장 가능

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
