### PR TITLE
[Feat] 결제 및 결과에 따른 성공/실패 페이지 생성, 이동 구현 

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { Feed } from "@/types/Feed";
 import { Streak } from "@/types/Streak";
 import { Challenge } from "./types/Challenge";
 import ChallengePaymentPage from "@components/payment/ChallengePaymentPage";
+import PaymentSuccessPage from "./components/payment/PaymentSuccessPage";
 
 function App() {
   const { user } = useUserStore();
@@ -140,6 +141,7 @@ function App() {
           path="challenge/:challengeId/order"
           element={<ChallengePaymentPage />}
         />
+        <Route path="/payment/success" element={<PaymentSuccessPage />} />
       </Routes>
     </div>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import { Streak } from "@/types/Streak";
 import { Challenge } from "./types/Challenge";
 import ChallengePaymentPage from "@components/payment/ChallengePaymentPage";
 import PaymentSuccessPage from "./components/payment/PaymentSuccessPage";
+import PaymentFailPage from "./components/payment/PaymentFailPage";
 
 function App() {
   const { user } = useUserStore();
@@ -142,6 +143,7 @@ function App() {
           element={<ChallengePaymentPage />}
         />
         <Route path="/payment/success" element={<PaymentSuccessPage />} />
+        <Route path="/payment/fail" element={<PaymentFailPage />} />
       </Routes>
     </div>
   );

--- a/frontend/src/api/payment.ts
+++ b/frontend/src/api/payment.ts
@@ -1,8 +1,5 @@
 import { get } from "@/api/api";
-
-export interface OrderIdResponse {
-  orderId: string;
-}
+import { OrderIdResponse } from "@/types/Payment";
 
 /**
  * 주어진 challengeId로 orderId만 반환받는 API 함수
@@ -12,3 +9,4 @@ export const getOrderId = async (
 ): Promise<OrderIdResponse> => {
   return get<OrderIdResponse>(`/payments/order/${challengeId}`);
 };
+

--- a/frontend/src/components/payment/ChallengePaymentPage.tsx
+++ b/frontend/src/components/payment/ChallengePaymentPage.tsx
@@ -12,7 +12,7 @@ import { Amount, ConfirmPaymentRequest } from "@/types/Payment";
 import { useConfirmPayment } from "@/hooks/usePayment";
 import { AxiosError } from "axios";
 
-const ChallengePaymentPage: React.FC = () => {
+function ChallengePaymentPage() {
   const { challengeId } = useParams<{ challengeId: string }>();
   const user = useUserStore.getState().user;
   const customerKey = user ? "user_" + user.id : null; // 고객 식별키
@@ -140,8 +140,9 @@ const ChallengePaymentPage: React.FC = () => {
       await confirmPayment(payload);
 
       // 성공 페이지로 이동, 뒤로가기 X
-      navigate(`/payment/success/${challengeId}`, {
+      navigate(`/payment/success`, {
         replace: true,
+        state: { challengeId },
       });
     } catch (err) {
       console.error("결제 오류:", err);
@@ -155,9 +156,9 @@ const ChallengePaymentPage: React.FC = () => {
       const errorMessage = body?.errorMessage;
 
       // 실패 페이지로 이동, 뒤로가기 X
-      navigate(`/payment/fail/${challengeId}`, {
+      navigate(`/payment/fail`, {
         replace: true,
-        state: { httpStatus, errorCode, errorMessage },
+        state: { httpStatus, errorCode, errorMessage, challengeId },
       });
     } finally {
       setIsOrdering(false);
@@ -207,6 +208,6 @@ const ChallengePaymentPage: React.FC = () => {
       </div>
     </div>
   );
-};
+}
 
 export default ChallengePaymentPage;

--- a/frontend/src/components/payment/ChallengePaymentPage.tsx
+++ b/frontend/src/components/payment/ChallengePaymentPage.tsx
@@ -8,6 +8,7 @@ import { useUserStore } from "@/stores/userStore";
 import { useParams } from "react-router";
 import { useChallenge } from "@/hooks/useChallenge";
 import { getOrderId } from "@/api/payment";
+import { FiArrowLeft } from "react-icons/fi";
 
 interface Amount {
   currency: "KRW";
@@ -118,7 +119,15 @@ const ChallengePaymentPage: React.FC = () => {
     <div className="flex min-h-screen w-full items-center justify-center bg-[#0E0E11]">
       <div className="flex min-h-screen flex-col gap-4 bg-white pt-4">
         <section className="flex w-[600px] flex-col items-center p-8">
-          <h1 className="mb-8 text-2xl font-bold">챌린지 결제</h1>
+          <div className="relative mb-8 flex w-full items-center justify-center">
+            <button
+              onClick={() => window.history.back()}
+              className="absolute left-[30px] flex cursor-pointer items-center text-2xl text-gray-400"
+            >
+              <FiArrowLeft />
+            </button>
+            <h1 className="text-2xl font-bold">챌린지 결제</h1>
+          </div>
           <div className="w-full px-[24px]">
             <div className="border-primary-purple-100 flex flex-col gap-2 rounded-md border p-8">
               <div className="flex justify-between gap-4">
@@ -133,14 +142,15 @@ const ChallengePaymentPage: React.FC = () => {
           </div>
           <div id="payment-method" className="w-full" />
           <div id="agreement" className="mb-6 w-full text-center" />
-
-          <button
-            onClick={onPayClick}
-            disabled={!isReady}
-            className="bg-primary-purple-400 disabled:bg-primary-purple-100 w-full cursor-pointer rounded-lg px-6 py-5 font-medium text-white disabled:cursor-default disabled:opacity-50"
-          >
-            결제하기
-          </button>
+          <div className="w-full px-[30px]">
+            <button
+              onClick={onPayClick}
+              disabled={!isReady}
+              className="bg-primary-purple-400 disabled:bg-primary-purple-100 w-full rounded-lg px-6 py-5 text-lg font-semibold text-white disabled:cursor-default disabled:opacity-50"
+            >
+              결제하기
+            </button>
+          </div>
         </section>
       </div>
     </div>

--- a/frontend/src/components/payment/PaymentFailPage.tsx
+++ b/frontend/src/components/payment/PaymentFailPage.tsx
@@ -1,0 +1,10 @@
+function PaymentFailPage() {
+  return (
+    <div>
+      <p>결제에 실패했습니다.</p>
+      <span>에러메시지</span>
+    </div>
+  );
+}
+
+export default PaymentFailPage;

--- a/frontend/src/components/payment/PaymentFailPage.tsx
+++ b/frontend/src/components/payment/PaymentFailPage.tsx
@@ -1,8 +1,42 @@
+import { FiX, FiXCircle } from "react-icons/fi";
+import { useLocation, useNavigate } from "react-router-dom";
+
 function PaymentFailPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { challengeId, errorMessage } = location.state || {};
+  if (!challengeId) return <p>잘못된 접근입니다.</p>;
+
   return (
-    <div>
-      <p>결제에 실패했습니다.</p>
-      <span>에러메시지</span>
+    <div className="flex min-h-screen items-center justify-center bg-[#0E0E11] p-4">
+      <div
+        className="relative flex w-full max-w-sm flex-col items-center gap-8 rounded-2xl border border-gray-700 bg-gray-800/80 p-12 shadow-2xl backdrop-blur-md"
+        style={{
+          boxShadow:
+            "0 0 20px rgba(255, 255, 255, 0.1), 0 0 10px rgba(255, 255, 255, 0.1)",
+        }}
+      >
+        <FiX
+          onClick={() => navigate("/challenge/search", { replace: true })}
+          className="absolute right-6 top-6 h-6 w-6 cursor-pointer text-gray-400 hover:text-white"
+        />
+        <div className="flex flex-col items-center gap-4">
+          <FiXCircle className="my-2 h-16 w-16 animate-pulse text-red-400" />
+          <h3 className="text-2xl font-extrabold text-white">결제 실패</h3>
+          <p className="text-center text-gray-300">
+            {errorMessage || "알 수 없는 오류가 발생했습니다."}
+          </p>
+        </div>
+
+        {challengeId && (
+          <button
+            onClick={() => navigate(`/challenge/${challengeId}/order`)}
+            className="bg-primary-purple-300 hover:bg-primary-purple-400 w-full cursor-pointer rounded-lg px-6 py-4 font-semibold text-white"
+          >
+            다시 시도하기
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/payment/PaymentSuccessPage.tsx
+++ b/frontend/src/components/payment/PaymentSuccessPage.tsx
@@ -1,22 +1,40 @@
-import { FiCheckCircle } from "react-icons/fi";
-import { useNavigate } from "react-router-dom";
+import { FiCheckCircle, FiX } from "react-icons/fi";
+import { useLocation, useNavigate } from "react-router-dom";
 
 function PaymentSuccessPage() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const { challengeId } = (location.state as { challengeId: string }) || {};
+  if (!challengeId) return <p>잘못된 접근입니다.</p>;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#0E0E11] p-4">
-      <div className="flex w-full max-w-sm flex-col items-center gap-6 rounded-2xl bg-gray-800/80 px-8 py-12 shadow-2xl backdrop-blur-md">
-        <FiCheckCircle className="text-primary-purple-300 h-16 w-16 animate-pulse" />
-        <h3 className="text-3xl font-extrabold text-white">결제 완료!</h3>
-        <p className="text-center text-gray-300">
-          당신의 더 멋진 오늘을 응원해요!
-        </p>
+      <div
+        className="relative flex w-full max-w-sm flex-col items-center gap-8 rounded-2xl border border-gray-700 bg-gray-800/80 p-12 shadow-2xl backdrop-blur-md"
+        style={{
+          boxShadow:
+            "0 0 20px rgba(255, 255, 255, 0.1), 0 0 10px rgba(255, 255, 255, 0.1)",
+        }}
+      >
+        <FiX
+          onClick={() => navigate("/challenge/search", { replace: true })}
+          className="absolute right-6 top-6 h-6 w-6 cursor-pointer text-gray-400 transition-colors hover:text-white"
+        />
+        <div className="flex flex-col items-center gap-4">
+          <FiCheckCircle className="text-primary-purple-300 my-2 h-16 w-16 animate-pulse" />
+          <h3 className="text-2xl font-extrabold text-white">결제 완료!</h3>
+          <p className="text-center text-gray-300">
+            당신의 더 멋진 오늘을 응원해요!
+          </p>
+        </div>
+
         <button
-          onClick={() => navigate("/challenges")}
-          className="bg-primary-purple-400 mt-4 transform cursor-pointer rounded-full px-8 py-4 font-semibold text-white"
+          onClick={() =>
+            navigate(`/challenges/${challengeId}`, { replace: true })
+          }
+          className="bg-primary-purple-300 hover:bg-primary-purple-400 w-full flex-1 transform cursor-pointer rounded-lg p-4 font-semibold text-white"
         >
-          챌린지 바로가기
+          챌린지 가기
         </button>
       </div>
     </div>

--- a/frontend/src/components/payment/PaymentSuccessPage.tsx
+++ b/frontend/src/components/payment/PaymentSuccessPage.tsx
@@ -1,0 +1,26 @@
+import { FiCheckCircle } from "react-icons/fi";
+import { useNavigate } from "react-router-dom";
+
+function PaymentSuccessPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#0E0E11] p-4">
+      <div className="flex w-full max-w-sm flex-col items-center gap-6 rounded-2xl bg-gray-800/80 px-8 py-12 shadow-2xl backdrop-blur-md">
+        <FiCheckCircle className="text-primary-purple-300 h-16 w-16 animate-pulse" />
+        <h3 className="text-3xl font-extrabold text-white">결제 완료!</h3>
+        <p className="text-center text-gray-300">
+          당신의 더 멋진 오늘을 응원해요!
+        </p>
+        <button
+          onClick={() => navigate("/challenges")}
+          className="bg-primary-purple-400 mt-4 transform cursor-pointer rounded-full px-8 py-4 font-semibold text-white"
+        >
+          챌린지 바로가기
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default PaymentSuccessPage;

--- a/frontend/src/hooks/usePayment.ts
+++ b/frontend/src/hooks/usePayment.ts
@@ -1,0 +1,6 @@
+import { ConfirmPaymentRequest } from "@/types/Payment";
+import { usePost } from "./useApiHooks";
+
+export function useConfirmPayment() {
+  return usePost<void, ConfirmPaymentRequest>("/payments/confirm");
+}

--- a/frontend/src/types/Payment.ts
+++ b/frontend/src/types/Payment.ts
@@ -1,0 +1,15 @@
+export interface OrderIdResponse {
+  orderId: string;
+}
+
+export interface ConfirmPaymentRequest {
+  challengeId: number;
+  orderId: string;
+  paymentKey: string;
+  amount: number;
+}
+
+export interface Amount {
+  currency: "KRW";
+  value: number;
+}


### PR DESCRIPTION
## 개요

Resolves: #151

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경


## 작업 내용

- 백엔드 서버에 결제 검증 요청 
- 결제 결과에 따른 페이지 이동 구현
- 결제 성공/실패 페이지 구현 및 페이지 이동시 스택에 저장하지 않도록 처리
- 결제 결과 페이지 내부에서 챌린지 페이지 또는 챌린지 결제 페이지로 재이동 할 수 있도록 함 

## 스크린샷

![스크린샷 2025-05-21 094157](https://github.com/user-attachments/assets/b3a6b4a7-e2a6-4f7d-a13a-3762d5e401e9)
![스크린샷 2025-05-21 094209](https://github.com/user-attachments/assets/45ed5c5b-c542-44d7-960d-cc0c3540d364)
