### PR TITLE
[Fix] 챌린지 결제 모듈이 불러와지지 않는 문제 

### DIFF
--- a/backend/demo/src/main/java/store/oneul/mvc/challenge/controller/ChallengeController.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/challenge/controller/ChallengeController.java
@@ -45,8 +45,16 @@ public class ChallengeController {
         return ResponseEntity.ok().build();
     }
 
+    /** 일반 챌린지 조회용(챌린지 신청, 결제) */
     @GetMapping("/{challengeId}")
-    public ResponseEntity<ChallengeDTO> getChallenge(
+    public ResponseEntity<ChallengeDTO> getChallengeById(@PathVariable Long challengeId) {
+    	ChallengeDTO dto = challengeService.getChallenge(challengeId);
+    	return ResponseEntity.ok(dto);
+    }
+    
+    /** 나의 챌린지 조회용(챌린지 디테일) */
+    @GetMapping("/my/{challengeId}")
+    public ResponseEntity<ChallengeDTO> getMyChallenge(
             @PathVariable Long challengeId,
             @AuthenticationPrincipal UserDTO loginUser) {
         

--- a/backend/demo/src/main/resources/mappers/ChallengeMapper.xml
+++ b/backend/demo/src/main/resources/mappers/ChallengeMapper.xml
@@ -7,7 +7,7 @@
 
     <!-- SELECT ONE -->
     <!-- 챌린지 상세 조회 + 방장 nickname + 로그인 유저의 success_day -->
-    <select id="getChallenge" parameterType="map" resultType="ChallengeDTO">
+    <select id="getMyChallenge" parameterType="map" resultType="ChallengeDTO">
 		SELECT 
 		    c.challenge_id,
 		    c.name,

--- a/frontend/src/components/challengeDetail/ChallengeDetailPage.tsx
+++ b/frontend/src/components/challengeDetail/ChallengeDetailPage.tsx
@@ -2,7 +2,7 @@ import ChallengeFeed from "./ChallengeFeed";
 import ChallengeDetail from "./ChellengeDetail";
 import ChallengeStatus from "./ChallengeStatus";
 import { useParams } from "react-router";
-import { useChallenge } from "@/hooks/useChallenge";
+import { useMyChallenge } from "@/hooks/useChallenge";
 
 function ChallengeDetailPage() {
   const { challengeId } = useParams<{ challengeId: string }>();
@@ -11,7 +11,7 @@ function ChallengeDetailPage() {
     isLoading,
     isError,
     error,
-  } = useChallenge(challengeId ?? "");
+  } = useMyChallenge(challengeId ?? "");
 
   if (!challengeId) return <p>잘못된 경로입니다.</p>;
 

--- a/frontend/src/hooks/useChallenge.ts
+++ b/frontend/src/hooks/useChallenge.ts
@@ -3,6 +3,18 @@ import { Challenge } from "@/types/Challenge";
 import { useGet } from "./useApiHooks";
 
 // 챌린지 정보 호출
+export function useMyChallenge(challengeId: string) {
+  return useGet<Challenge>(
+    ["myChallenge", challengeId],
+    `/challenges/my/${challengeId}`,
+    {
+      staleTime: 1000 * 60 * 10,
+      gcTime: 1000 * 60 * 30,
+      enabled: Boolean(challengeId),
+    },
+  );
+}
+
 export function useChallenge(challengeId: string) {
   return useGet<Challenge>(
     ["challenge", challengeId],


### PR DESCRIPTION
## 개요

Resolves: #150 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정

## 작업 내용

- 챌린지 단건 조회에 실패하여 챌린지 모듈을 불러오지 못하는 문제 
-> 챌린지 조회 요청이 userID를 통해 join하여 successDay를 반환하는 mapper와만 연결되어 있어 챌린지 데이터를 불러오지 못하는 상황임을 확인
-> controller에 기존 챌린지 단건 조회(참여하는 챌린지 방의 디테일 정보) 요청 api 주소를 `/api/challenges/my/{challengeId}`로 수정, 일반 챌린지 단건 조회 매핑 (`/api/challenges/{challengeId}`
- 프론트 챌린지 단건 조회 쿼리 훅도 분류하여 사용하는 것으로 수정 
