### PR TITLE
[Feat] 결제 성공 시 payment 및 challenge_user 저장 및 트랜잭션 실패 감지 로직 추가

### DIFF
--- a/backend/demo/src/main/java/store/oneul/mvc/challenge/dao/ChallengeDAO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/challenge/dao/ChallengeDAO.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.apache.ibatis.annotations.Mapper;
 
 import store.oneul.mvc.challenge.dto.ChallengeDTO;
+import store.oneul.mvc.challenge.dto.ChallengeUserDTO;
 
 @Mapper
 public interface ChallengeDAO {
@@ -25,5 +26,7 @@ public interface ChallengeDAO {
     List<ChallengeDTO> getCommunityChallenges();
 
 	ChallengeDTO getChallengeById(Long challengeId);
+
+    int insertChallengeUser(ChallengeUserDTO dto);
 
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/challenge/dto/ChallengeUserDTO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/challenge/dto/ChallengeUserDTO.java
@@ -1,0 +1,18 @@
+package store.oneul.mvc.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeUserDTO {
+    private Long challengeId;
+    private Long userId;
+    private int successDay;       // 기본 0
+    private boolean isRefunded;   // 기본 false
+    private int refundAmount;     // 기본 0
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dao/PaymentDAO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dao/PaymentDAO.java
@@ -2,7 +2,11 @@ package store.oneul.mvc.payment.dao;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import store.oneul.mvc.payment.dto.PaymentDTO;
+
 @Mapper
 public interface PaymentDAO {
     boolean existsByPaymentKey(String paymentKey);
+
+    int insert(PaymentDTO dto);
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dto/PaymentDTO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dto/PaymentDTO.java
@@ -1,0 +1,19 @@
+package store.oneul.mvc.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentDTO {
+    private Long userId;
+    private Long challengeId;
+    private String orderId;
+    private String paymentKey;
+    private int amount;
+    private String status; // "PAID", "CANCELED" 등
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/event/PaymentConfirmedEvent.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/event/PaymentConfirmedEvent.java
@@ -1,0 +1,14 @@
+package store.oneul.mvc.payment.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PaymentConfirmedEvent {
+    private Long userId;
+    private Long challengeId;
+    private String orderId;
+    private String paymentKey;
+    private int amount;
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/PaymentSaveService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/PaymentSaveService.java
@@ -1,0 +1,66 @@
+package store.oneul.mvc.payment.service;
+
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import store.oneul.mvc.challenge.dao.ChallengeDAO;
+import store.oneul.mvc.challenge.dto.ChallengeUserDTO;
+import store.oneul.mvc.payment.dao.PaymentDAO;
+import store.oneul.mvc.payment.dto.PaymentDTO;
+import store.oneul.mvc.payment.dto.TossConfirmResponse;
+import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentSaveService {
+
+    private final PaymentDAO paymentDAO;
+    private final ChallengeDAO challengeDAO;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void save(Long userId, Long challengeId, TossConfirmResponse tossResponse) {
+        // 1. payment INSERT
+        PaymentDTO payment = new PaymentDTO();
+        payment.setUserId(userId);
+        payment.setChallengeId(challengeId);
+        payment.setOrderId(tossResponse.getOrderId());
+        payment.setPaymentKey(tossResponse.getPaymentKey());
+        payment.setAmount(tossResponse.getAmount());
+        payment.setStatus("PAID");
+        int result = paymentDAO.insert(payment);
+        if (result != 1) {
+        	System.out.println(result);
+        	log.error("[❌결제 실패] payment insert 실패! orderId: {}", tossResponse.getOrderId());
+        	throw new RuntimeException("payment insert failed");
+        }
+        // 2. challenge_user INSERT
+        ChallengeUserDTO challengeUser = new ChallengeUserDTO();
+        challengeUser.setUserId(userId);
+        challengeUser.setChallengeId(challengeId);
+        challengeUser.setSuccessDay(0);
+        challengeUser.setRefunded(false);
+        challengeUser.setRefundAmount(0);
+        result = challengeDAO.insertChallengeUser(challengeUser);
+        if (result != 1) {
+        	
+        	log.error("[❌결제 실패] challengeUser insert 실패! ");
+            throw new RuntimeException("ChallengeUser insert failed");
+        }
+        // 3. 이벤트 발행 (실패 대비)
+        eventPublisher.publishEvent(
+            new PaymentConfirmedEvent(
+                userId,
+                challengeId,
+                tossResponse.getOrderId(),
+                tossResponse.getPaymentKey(),
+                tossResponse.getAmount()
+            )
+        );
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/usecase/PaymentUsecase.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/usecase/PaymentUsecase.java
@@ -1,10 +1,12 @@
 package store.oneul.mvc.payment.usecase;
 
 import org.springframework.stereotype.Service;
+
 import lombok.RequiredArgsConstructor;
 import store.oneul.mvc.payment.dto.PaymentConfirmRequest;
 import store.oneul.mvc.payment.dto.PaymentSessionDto;
 import store.oneul.mvc.payment.dto.TossConfirmResponse;
+import store.oneul.mvc.payment.service.PaymentSaveService;
 import store.oneul.mvc.payment.service.TossConfirmService;
 import store.oneul.mvc.payment.validator.PaymentValidator;
 
@@ -14,27 +16,21 @@ public class PaymentUsecase {
 
     private final PaymentValidator paymentValidator;
     private final TossConfirmService tossConfirmService;
-    //private final PaymentSaveService paymentSaveService;
-    //private final CompensationService compensationService;
+    private final PaymentSaveService paymentSaveService;
 
     public TossConfirmResponse confirmPayment(Long userId, PaymentConfirmRequest request) {
-        try {
-            // 1. Redis + DB 기반 검증
-            PaymentSessionDto session = paymentValidator.validate(userId, request);
 
-            // 2. Toss API 결제 승인 호출
-            TossConfirmResponse tossResponse = tossConfirmService.confirm(request);
+        // 1. Redis + DB 기반 검증
+        PaymentSessionDto session = paymentValidator.validate(userId, request);
 
-            // 3. DB 저장 (@Transactional 내부)
-            // paymentSaveService.save(userId, session.getChallengeId(), tossResponse);
+        // 2. Toss API 결제 승인 호출
+        TossConfirmResponse tossResponse = tossConfirmService.confirm(request);
 
-            // 4. 성공 응답 반환
-            return tossResponse;
+        // 3. DB 저장 (@Transactional 내부)
+        // paymentSaveService.save(userId, session.getChallengeId(), tossResponse);
 
-        } catch (Exception e) {
-            // 5. 실패 시 보상 트랜잭션 처리
-            // compensationService.handleConfirmFail(userId, request);
-            throw e;
-        }
+        // 4. 성공 응답 반환
+        return tossResponse;
+
     }
 }

--- a/backend/demo/src/main/resources/mappers/ChallengeMapper.xml
+++ b/backend/demo/src/main/resources/mappers/ChallengeMapper.xml
@@ -106,6 +106,23 @@
 	<select id="getChallengeById" resultType="ChallengeDTO">
 	  SELECT * FROM challenge WHERE challenge_id = #{challengeId}
 	</select>
+	
+	
+    <insert id="insertChallengeUser" parameterType="ChallengeUserDTO">
+        INSERT INTO challenge_user (
+            challenge_id,
+            user_id,
+            success_day,
+            is_refunded,
+            refund_amount
+        ) VALUES (
+            #{challengeId},
+            #{userId},
+            #{successDay},
+            #{isRefunded},
+            #{refundAmount}
+        )
+    </insert>
 	    
 
 </mapper>

--- a/backend/demo/src/main/resources/mappers/PaymentMapper.xml
+++ b/backend/demo/src/main/resources/mappers/PaymentMapper.xml
@@ -11,4 +11,24 @@
             WHERE payment_key = #{paymentKey}
         )
     </select>
+    
+        <insert id="insert" parameterType="PaymentDTO">
+        INSERT INTO payment (
+            user_id,
+            challenge_id,
+            order_id,
+            payment_key,
+            amount,
+            status
+        ) VALUES (
+            #{userId},
+            #{challengeId},
+            #{orderId},
+            #{paymentKey},
+            #{amount},
+            #{status}
+        )
+    </insert>
+    
+    
 </mapper>


### PR DESCRIPTION
## 개요

Resolves: #154 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용
- PaymentSaveService 신규 생성: @Transactional로 결제 저장 처리
- PaymentDTO, ChallengeUserDTO 생성: insert용 DTO
- paymentMapper.xml, challengeMapper.xml 및 DAO 인터페이스 작성
- PaymentUsecase에서 저장 로직 분리 및 save() 호출
- 트랜잭션 실패 감지를 위한 PaymentConfirmedEvent 클래스 생성
- 이벤트 발행 후, @TransactionalEventListener(AFTER_ROLLBACK) 구조로 보상 처리 시작점 구성
