### PR TITLE
[Feat] Toss 결제 보상 트랜잭션 처리 및 응답 분기 구조 구현

### DIFF
--- a/backend/demo/src/main/java/store/oneul/mvc/payment/calculator/RefundAmountCalculator.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/calculator/RefundAmountCalculator.java
@@ -1,0 +1,26 @@
+package store.oneul.mvc.payment.calculator;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import store.oneul.mvc.payment.enums.RefundReason;
+
+public class RefundAmountCalculator {
+
+    public static int calculate(int entryFee, LocalDate startDate, LocalDate now, RefundReason reason) {
+        switch (reason) {
+            case TX_FAIL:
+                return entryFee;
+            case CHALLENGE_SUCCESS:
+                return (int) (entryFee * 0.78); // 세금 22% 제외
+            case USER_CANCEL:
+                if (now.isBefore(startDate)) return entryFee;
+                long days = ChronoUnit.DAYS.between(startDate, now);
+                if (days <= 4) return (int) (entryFee * 0.8);
+                if (days <= 7) return (int) (entryFee * 0.5);
+                return 0;
+            default:
+                return 0;
+        }
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/client/TossClient.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/client/TossClient.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import store.oneul.mvc.payment.dto.PaymentConfirmRequest;
+import store.oneul.mvc.payment.dto.TossCancelRequest;
 import store.oneul.mvc.payment.dto.TossConfirmRequest;
 import store.oneul.mvc.payment.dto.TossConfirmResponse;
 import store.oneul.mvc.payment.dto.TossErrorInfo;
@@ -55,6 +56,22 @@ public class TossClient {
             } catch (Exception ex) {
                 throw new RuntimeException("결제 실패 응답 파싱 오류", ex);
             }
+        }
+    }
+    public void cancel(String paymentKey, TossCancelRequest request) {
+        String encodedSecret = Base64.getEncoder()
+                .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+
+        try {
+            tossRestClient.post()
+                .uri("/" + paymentKey + "/cancel")
+                .header(HttpHeaders.AUTHORIZATION, "Basic " + encodedSecret)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .toBodilessEntity(); // Toss는 성공 시 response body 없음
+        } catch (HttpClientErrorException e) {
+            throw new RuntimeException("Toss Cancel 실패: " + e.getResponseBodyAsString(), e);
         }
     }
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dao/PaymentDAO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dao/PaymentDAO.java
@@ -3,10 +3,13 @@ package store.oneul.mvc.payment.dao;
 import org.apache.ibatis.annotations.Mapper;
 
 import store.oneul.mvc.payment.dto.PaymentDTO;
+import store.oneul.mvc.payment.dto.RefundReceiptDTO;
 
 @Mapper
 public interface PaymentDAO {
     boolean existsByPaymentKey(String paymentKey);
 
-    int insert(PaymentDTO dto);
+    int insertPayment(PaymentDTO dto);
+    
+    int insertRefundReceipt(RefundReceiptDTO receipt);
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dto/PaymentResultResponse.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dto/PaymentResultResponse.java
@@ -1,0 +1,67 @@
+package store.oneul.mvc.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class PaymentResultResponse {
+
+    private String status; // SUCCESS, ROLLBACK_REFUNDED, ROLLBACK_FAILED, TOSS_CONFIRM_FAILED
+    private String message;
+
+    private boolean manualRefundRequired;
+
+    // Toss 결제 성공 시 제공
+    private String orderId;
+    private String paymentKey;
+    private Integer paidAmount;
+    private String approvedAt;
+
+    // Toss 환불 성공 시 제공
+    private Integer refundedAmount;
+    private String refundedAt;
+
+    // ✅ 결제 성공
+    public static PaymentResultResponse success(TossConfirmResponse res) {
+        return PaymentResultResponse.builder()
+                .status("SUCCESS")
+                .message("결제가 완료되었습니다.")
+                .manualRefundRequired(false)
+                .orderId(res.getOrderId())
+                .paymentKey(res.getPaymentKey())
+                .paidAmount(res.getAmount())
+                .approvedAt(res.getApprovedAt())
+                .build();
+    }
+
+    // ✅ 자동 환불 완료 (cancel 성공)
+    public static PaymentResultResponse refunded(TossConfirmResponse res, int refundAmount, String refundedAt) {
+        return PaymentResultResponse.builder()
+                .status("ROLLBACK_REFUNDED")
+                .message("결제 오류로 인해 환불 처리되었습니다.")
+                .manualRefundRequired(false)
+                .orderId(res.getOrderId())
+                .paymentKey(res.getPaymentKey())
+                .paidAmount(res.getAmount())
+                .approvedAt(res.getApprovedAt())
+                .refundedAmount(refundAmount)
+                .refundedAt(refundedAt)
+                .build();
+    }
+
+    // ✅ TossCancel 실패 → 수동 환불 유도
+    public static PaymentResultResponse manualRefundRequired(TossConfirmResponse res) {
+        return PaymentResultResponse.builder()
+                .status("ROLLBACK_FAILED")
+                .message("환불에 실패했습니다. 계좌 정보를 제출해주세요.")
+                .manualRefundRequired(true)
+                .orderId(res.getOrderId())
+                .paymentKey(res.getPaymentKey())
+                .paidAmount(res.getAmount())
+                .approvedAt(res.getApprovedAt())
+                .build();
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dto/RefundReceiptDTO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dto/RefundReceiptDTO.java
@@ -1,0 +1,18 @@
+package store.oneul.mvc.payment.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class RefundReceiptDTO {
+    private Long paymentId;           // Optional
+    private Long cancelFailLogId;     // Optional
+    private Long userId;
+    private Long challengeId;
+    private String refundMethod;      // TOSS_AUTO / MANUAL_BANK
+    private int refundAmount;
+    private LocalDateTime refundedAt;
+    private String transactionId;     // Toss 기준: receiptKey or transaction id
+    private String note;
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dto/TossCancelRequest.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dto/TossCancelRequest.java
@@ -1,0 +1,11 @@
+package store.oneul.mvc.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TossCancelRequest {
+    private int cancelAmount;
+    private String cancelReason;
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/enums/RefundReason.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/enums/RefundReason.java
@@ -1,0 +1,7 @@
+package store.oneul.mvc.payment.enums;
+
+public enum RefundReason {
+    TX_FAIL,             // 트랜잭션 롤백 시 자동 환불
+    USER_CANCEL,         // 유저가 자발적으로 환불 요청
+    CHALLENGE_SUCCESS    // 챌린지 성공 → 세금 제외 환급
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/event/CompensationEventHandler.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/event/CompensationEventHandler.java
@@ -1,0 +1,23 @@
+package store.oneul.mvc.payment.event;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import store.oneul.mvc.payment.service.CompensationService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CompensationEventHandler {
+
+    private final CompensationService compensationService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
+    public void onRollback(PaymentConfirmedEvent event) {
+        log.warn("🌀 트랜잭션 롤백 감지 - Toss 결제 취소 시도");
+        compensationService.handleConfirmFail(event);
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/CompensationService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/CompensationService.java
@@ -1,0 +1,8 @@
+package store.oneul.mvc.payment.service;
+
+import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
+
+public interface CompensationService {
+
+    void handleConfirmFail(PaymentConfirmedEvent event);  // 결제 실패 시 보상 처리
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/CompensationServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/CompensationServiceImpl.java
@@ -1,0 +1,33 @@
+package store.oneul.mvc.payment.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import store.oneul.mvc.payment.enums.RefundReason;
+import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CompensationServiceImpl implements CompensationService {
+
+    private final TossCancelService tossCancelService;
+    private final RefundReceiptService refundReceiptService;
+
+    @Override
+    public void handleConfirmFail(PaymentConfirmedEvent event) {
+        try {
+            log.warn("보상 트랜잭션 시작 - Toss Cancel 요청");
+
+            int refundAmount = tossCancelService.cancel(event, RefundReason.TX_FAIL);
+
+            // db 저장 실패로 인한 환불
+            refundReceiptService.recordAutoRefund(event, refundAmount, "DB 저장 실패로 인한 자동 환불");
+
+        } catch (Exception e) {
+            log.error("❌ Toss Cancel 실패 - DLQ 적재 예정", e);
+            // TODO: Redis DLQ 적재
+        }
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/PaymentSaveService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/PaymentSaveService.java
@@ -1,66 +1,8 @@
 package store.oneul.mvc.payment.service;
 
-
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import store.oneul.mvc.challenge.dao.ChallengeDAO;
-import store.oneul.mvc.challenge.dto.ChallengeUserDTO;
-import store.oneul.mvc.payment.dao.PaymentDAO;
-import store.oneul.mvc.payment.dto.PaymentDTO;
 import store.oneul.mvc.payment.dto.TossConfirmResponse;
-import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
 
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class PaymentSaveService {
+public interface PaymentSaveService {
 
-    private final PaymentDAO paymentDAO;
-    private final ChallengeDAO challengeDAO;
-    private final ApplicationEventPublisher eventPublisher;
-
-    @Transactional
-    public void save(Long userId, Long challengeId, TossConfirmResponse tossResponse) {
-        // 1. payment INSERT
-        PaymentDTO payment = new PaymentDTO();
-        payment.setUserId(userId);
-        payment.setChallengeId(challengeId);
-        payment.setOrderId(tossResponse.getOrderId());
-        payment.setPaymentKey(tossResponse.getPaymentKey());
-        payment.setAmount(tossResponse.getAmount());
-        payment.setStatus("PAID");
-        int result = paymentDAO.insert(payment);
-        if (result != 1) {
-        	System.out.println(result);
-        	log.error("[❌결제 실패] payment insert 실패! orderId: {}", tossResponse.getOrderId());
-        	throw new RuntimeException("payment insert failed");
-        }
-        // 2. challenge_user INSERT
-        ChallengeUserDTO challengeUser = new ChallengeUserDTO();
-        challengeUser.setUserId(userId);
-        challengeUser.setChallengeId(challengeId);
-        challengeUser.setSuccessDay(0);
-        challengeUser.setRefunded(false);
-        challengeUser.setRefundAmount(0);
-        result = challengeDAO.insertChallengeUser(challengeUser);
-        if (result != 1) {
-        	
-        	log.error("[❌결제 실패] challengeUser insert 실패! ");
-            throw new RuntimeException("ChallengeUser insert failed");
-        }
-        // 3. 이벤트 발행 (실패 대비)
-        eventPublisher.publishEvent(
-            new PaymentConfirmedEvent(
-                userId,
-                challengeId,
-                tossResponse.getOrderId(),
-                tossResponse.getPaymentKey(),
-                tossResponse.getAmount()
-            )
-        );
-    }
+    void save(Long userId, Long challengeId, TossConfirmResponse tossResponse);  // 결제 저장 및 처리
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/PaymentSaveServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/PaymentSaveServiceImpl.java
@@ -1,0 +1,66 @@
+package store.oneul.mvc.payment.service;
+
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import store.oneul.mvc.challenge.dao.ChallengeDAO;
+import store.oneul.mvc.challenge.dto.ChallengeUserDTO;
+import store.oneul.mvc.payment.dao.PaymentDAO;
+import store.oneul.mvc.payment.dto.PaymentDTO;
+import store.oneul.mvc.payment.dto.TossConfirmResponse;
+import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentSaveServiceImpl implements PaymentSaveService{
+
+    private final PaymentDAO paymentDAO;
+    private final ChallengeDAO challengeDAO;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void save(Long userId, Long challengeId, TossConfirmResponse tossResponse) {
+        // 1. payment INSERT
+        PaymentDTO payment = new PaymentDTO();
+        payment.setUserId(userId);
+        payment.setChallengeId(challengeId);
+        payment.setOrderId(tossResponse.getOrderId());
+        payment.setPaymentKey(tossResponse.getPaymentKey());
+        payment.setAmount(tossResponse.getAmount());
+        payment.setStatus("PAID");
+        int result = paymentDAO.insertPayment(payment);
+        if (result != 1) {
+        	System.out.println(result);
+        	log.error("[❌결제 실패] payment insert 실패! orderId: {}", tossResponse.getOrderId());
+        	throw new RuntimeException("payment insert failed");
+        }
+        // 2. challenge_user INSERT
+        ChallengeUserDTO challengeUser = new ChallengeUserDTO();
+        challengeUser.setUserId(userId);
+        challengeUser.setChallengeId(challengeId);
+        challengeUser.setSuccessDay(0);
+        challengeUser.setRefunded(false);
+        challengeUser.setRefundAmount(0);
+        result = challengeDAO.insertChallengeUser(challengeUser);
+        if (result != 1) {
+        	
+        	log.error("[❌결제 실패] challengeUser insert 실패! ");
+            throw new RuntimeException("ChallengeUser insert failed");
+        }
+        // 3. 이벤트 발행 (실패 대비)
+        eventPublisher.publishEvent(
+            new PaymentConfirmedEvent(
+                userId,
+                challengeId,
+                tossResponse.getOrderId(),
+                tossResponse.getPaymentKey(),
+                tossResponse.getAmount()
+            )
+        );
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/RefundReceiptService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/RefundReceiptService.java
@@ -1,0 +1,11 @@
+package store.oneul.mvc.payment.service;
+
+import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
+
+public interface RefundReceiptService {
+
+    void recordAutoRefund(PaymentConfirmedEvent event, int refundAmount, String reason);
+    
+    // 필요 시 수동 환불 확장도 가능
+    // void recordManualRefund(...);
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/RefundReceiptServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/RefundReceiptServiceImpl.java
@@ -1,0 +1,35 @@
+package store.oneul.mvc.payment.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import store.oneul.mvc.payment.dao.PaymentDAO;
+import store.oneul.mvc.payment.dto.RefundReceiptDTO;
+import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefundReceiptServiceImpl implements RefundReceiptService {
+
+    private final PaymentDAO paymentDAO;
+
+    @Override
+    public void recordAutoRefund(PaymentConfirmedEvent event, int refundAmount, String reason) {
+        RefundReceiptDTO receipt = new RefundReceiptDTO();
+        receipt.setUserId(event.getUserId());
+        receipt.setChallengeId(event.getChallengeId());
+        receipt.setPaymentId(null); // 결제 실패 시 null
+        receipt.setRefundMethod("TOSS_AUTO");
+        receipt.setRefundAmount(refundAmount);
+        receipt.setRefundedAt(LocalDateTime.now());
+        receipt.setTransactionId("TOSS_CANCEL_" + event.getPaymentKey());
+        receipt.setNote("orderId: " + event.getOrderId() + " / " + reason);
+
+        paymentDAO.insertRefundReceipt(receipt);
+        log.info("💾 환불 내역 저장 완료 (userId: {}, amount: {})", event.getUserId(), refundAmount);
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/TossCancelService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/TossCancelService.java
@@ -1,0 +1,9 @@
+package store.oneul.mvc.payment.service;
+
+import store.oneul.mvc.payment.enums.RefundReason;
+import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
+
+public interface TossCancelService {
+
+	public int cancel(PaymentConfirmedEvent event, RefundReason reason);
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/TossCancelServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/TossCancelServiceImpl.java
@@ -1,0 +1,42 @@
+package store.oneul.mvc.payment.service;
+
+import java.time.LocalDate;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import store.oneul.mvc.challenge.dao.ChallengeDAO;
+import store.oneul.mvc.challenge.dto.ChallengeDTO;
+import store.oneul.mvc.payment.client.TossClient;
+import store.oneul.mvc.payment.calculator.RefundAmountCalculator;
+import store.oneul.mvc.payment.dto.TossCancelRequest;
+import store.oneul.mvc.payment.enums.RefundReason;
+import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TossCancelServiceImpl implements TossCancelService {
+
+    private final TossClient tossClient;
+    private final ChallengeDAO challengeDAO;
+
+    public int cancel(PaymentConfirmedEvent event, RefundReason reason) {
+        ChallengeDTO challenge = challengeDAO.getChallengeById(event.getChallengeId());
+
+        int refundAmount = RefundAmountCalculator.calculate(
+            challenge.getEntryFee(),
+            challenge.getStartDate(),
+            LocalDate.now(),
+            reason
+        );
+
+        TossCancelRequest request = new TossCancelRequest(refundAmount, "자동 환불 처리: " + reason.name());
+        tossClient.cancel(event.getPaymentKey(), request);
+
+        log.info("✅ Toss 결제 취소 성공 (paymentKey: {}, refundAmount: {})", event.getPaymentKey(), refundAmount);
+        return refundAmount;
+    }
+}
+

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/TossConfirmService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/TossConfirmService.java
@@ -1,18 +1,10 @@
 package store.oneul.mvc.payment.service;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import store.oneul.mvc.payment.client.TossClient;
 import store.oneul.mvc.payment.dto.PaymentConfirmRequest;
 import store.oneul.mvc.payment.dto.TossConfirmResponse;
 
-@Service
-@RequiredArgsConstructor
-public class TossConfirmService {
+public interface TossConfirmService {
+	
+	public TossConfirmResponse confirm(PaymentConfirmRequest request);
 
-    private final TossClient tossClient;
-
-    public TossConfirmResponse confirm(PaymentConfirmRequest request) {
-        return tossClient.confirm(request);
-    }
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/TossConfirmServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/TossConfirmServiceImpl.java
@@ -1,0 +1,18 @@
+package store.oneul.mvc.payment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import store.oneul.mvc.payment.client.TossClient;
+import store.oneul.mvc.payment.dto.PaymentConfirmRequest;
+import store.oneul.mvc.payment.dto.TossConfirmResponse;
+
+@Service
+@RequiredArgsConstructor
+public class TossConfirmServiceImpl implements TossConfirmService {
+
+    private final TossClient tossClient;
+
+    public TossConfirmResponse confirm(PaymentConfirmRequest request) {
+        return tossClient.confirm(request);
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/usecase/PaymentUsecase.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/usecase/PaymentUsecase.java
@@ -3,13 +3,20 @@ package store.oneul.mvc.payment.usecase;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import store.oneul.mvc.payment.dto.PaymentConfirmRequest;
+import store.oneul.mvc.payment.dto.PaymentResultResponse;
 import store.oneul.mvc.payment.dto.PaymentSessionDto;
 import store.oneul.mvc.payment.dto.TossConfirmResponse;
+import store.oneul.mvc.payment.enums.RefundReason;
+import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
 import store.oneul.mvc.payment.service.PaymentSaveService;
+import store.oneul.mvc.payment.service.RefundReceiptService;
+import store.oneul.mvc.payment.service.TossCancelService;
 import store.oneul.mvc.payment.service.TossConfirmService;
 import store.oneul.mvc.payment.validator.PaymentValidator;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentUsecase {
@@ -17,21 +24,54 @@ public class PaymentUsecase {
     private final PaymentValidator paymentValidator;
     private final TossConfirmService tossConfirmService;
     private final PaymentSaveService paymentSaveService;
+    private final TossCancelService tossCancelService;
+    private final RefundReceiptService refundReceiptService;
 
-    public TossConfirmResponse confirmPayment(Long userId, PaymentConfirmRequest request) {
+    public PaymentResultResponse confirmPayment(Long userId, PaymentConfirmRequest request) {
 
         // 1. Redis + DB 기반 검증
         PaymentSessionDto session = paymentValidator.validate(userId, request);
 
-        // 2. Toss API 결제 승인 호출
+        // 2. Toss API 결제 승인
         TossConfirmResponse tossResponse = tossConfirmService.confirm(request);
 
-        // 3. DB 저장 (@Transactional 내부)
-        paymentSaveService.save(userId, session.getChallengeId(), tossResponse);
+        // 3. PaymentConfirmedEvent 생성 (재사용)
+        PaymentConfirmedEvent event = new PaymentConfirmedEvent(
+                userId,
+                session.getChallengeId(),
+                tossResponse.getOrderId(),
+                tossResponse.getPaymentKey(),
+                tossResponse.getAmount()
+        );
 
+        try {
+            // 4. DB 저장 시도 (내부 @Transactional)
+            paymentSaveService.save(userId, session.getChallengeId(), tossResponse);
 
-        // 4. 성공 응답 반환
-        return tossResponse;
+            // 5. 성공 응답
+            return PaymentResultResponse.success(tossResponse);
 
+        } catch (Exception e) {
+            log.error("❌ 결제 저장 실패 → TossCancel 보상 처리 진입", e);
+
+            try {
+                // 6. Toss 결제 취소
+                int refundAmount = tossCancelService.cancel(event, RefundReason.TX_FAIL);
+
+                // 7. 환불 내역 저장 (환불 시각은 지금 시간 기준)
+                String refundedAt = java.time.LocalDateTime.now().toString(); // ISO 8601 포맷
+
+                refundReceiptService.recordAutoRefund(event, refundAmount, "결제 저장 실패에 따른 자동 환불");
+
+                // 8. 응답 반환
+                return PaymentResultResponse.refunded(tossResponse, refundAmount, refundedAt);
+
+            } catch (Exception ex) {
+                log.error("❌ TossCancel 또는 환불기록 실패 → 수동 환불 전환 필요", ex);
+
+                // 9. 수동 환불 응답 반환
+                return PaymentResultResponse.manualRefundRequired(tossResponse);
+            }
+        }
     }
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/validator/PaymentValidator.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/validator/PaymentValidator.java
@@ -18,7 +18,7 @@ public class PaymentValidator {
     private final PaymentDAO paymentDAO;
 
     public PaymentSessionDto validate(Long userId, PaymentConfirmRequest request) {
-        String redisKey = "payment:session:user:" + userId;
+    	String redisKey = "payment:session:user:" + userId + ":challenge:" + request.getChallengeId();
         PaymentSessionDto session = (PaymentSessionDto) jsonRedisTemplate.opsForValue().get(redisKey);
 
         if (session == null) {

--- a/backend/demo/src/main/resources/mappers/PaymentMapper.xml
+++ b/backend/demo/src/main/resources/mappers/PaymentMapper.xml
@@ -12,7 +12,7 @@
         )
     </select>
     
-        <insert id="insert" parameterType="PaymentDTO">
+        <insert id="insertPayment" parameterType="PaymentDTO">
         INSERT INTO payment (
             user_id,
             challenge_id,
@@ -29,6 +29,30 @@
             #{status}
         )
     </insert>
+    
+     <insert id="insertRefundReceipt" parameterType="RefundReceiptDTO">
+	    INSERT INTO refund_receipt (
+	      payment_id,
+	      cancel_fail_log_id,
+	      user_id,
+	      challenge_id,
+	      refund_method,
+	      refund_amount,
+	      refunded_at,
+	      transaction_id,
+	      note
+	    ) VALUES (
+	      #{paymentId},
+	      #{cancelFailLogId},
+	      #{userId},
+	      #{challengeId},
+	      #{refundMethod},
+	      #{refundAmount},
+	      #{refundedAt},
+	      #{transactionId},
+	      #{note}
+	    )
+  	</insert>
     
     
 </mapper>


### PR DESCRIPTION
## 개요

Resolves: #155 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용
- PaymentResultResponse 생성: TossConfirm, TossCancel 결과를 사용자에게 응답
- PaymentUsecase에서 try-catch로 DB 저장 실패 시 보상 로직 실행
- Toss Cancel API 연동 (TossClient.cancel())
- 환불 금액 계산 로직 RefundAmountCalculator 도입
- refund_receipt 테이블에 TossCancel 성공 내역 기록
- RefundReason enum 도입 (TX_FAIL, USER_CANCEL, CHALLENGE_SUCCESS 등)
- @TransactionalEventListener 기반 보상 로직 제거 
- 서비스 클래스 책임 분리: TossConfirmService, TossCancelService, RefundReceiptService
- 레디스 orderId 저장시 key 기존 userId로만 만듬. 복합키 구조로 변경-> userId+challengeId
