### PR TITLE
[Fix] JWT 재발급 로직 구현 완료, 쿠키 반영 실패 이슈 있음

### DIFF
--- a/backend/demo/src/main/java/store/oneul/mvc/security/jwt/JwtAuthenticationFilter.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/security/jwt/JwtAuthenticationFilter.java
@@ -11,9 +11,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import store.oneul.mvc.security.rtr.RefreshTokenService;
+import store.oneul.mvc.security.token.TokenHelper;
 import store.oneul.mvc.user.dto.UserDTO;
 import store.oneul.mvc.user.service.UserService;
 
@@ -23,35 +26,99 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final UserService userService;
+    private final RefreshTokenService refreshTokenService;
+    private final TokenHelper tokenHelper; // ✅ 추가
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain chain) throws ServletException, IOException {
 
+        logTokensFromCookies(request); // 🍪 단순 로그
+
         String header = request.getHeader("Authorization");
+        String accessToken = (header != null && header.startsWith("Bearer ")) ? header.substring(7) : null;
 
-        if (header != null && header.startsWith("Bearer ")) {
+        if (accessToken != null) {
             try {
-                String token = header.substring(7);
-                Long userId = jwtProvider.getUserIdFromToken(token);
+                System.out.println("accesstoken null 들어옴");
 
-                UserDTO user = userService.findById(userId);
-                if (user != null) {
-                    UsernamePasswordAuthenticationToken authentication =
-                            new UsernamePasswordAuthenticationToken(
-                                    user,
-                                    null,
-                                    List.of(new SimpleGrantedAuthority("ROLE_USER"))
-                            );
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                    System.out.println("[AUTH] ✅ 인증 성공: userId = " + userId);
+                Long userId = jwtProvider.getUserIdFromToken(accessToken);
+
+                if (!jwtProvider.isTokenExpired(accessToken)) {
+                    // ✅ accessToken 유효
+                    authenticateUser(userId);
+                    chain.doFilter(request, response);
+                    return;
                 }
+
+                // ❗ accessToken 만료 → 쿠키에서 refreshToken 꺼내서 재발급 시도
+                String refreshToken = getTokenFromCookies(request, "refreshToken");
+                System.out.println("jwtAu~~refreshToken:: " + refreshToken);
+
+                if (refreshToken != null && refreshTokenService.validate(String.valueOf(userId), refreshToken)) {
+                    String newAccessToken = jwtProvider.createToken(userId);
+
+                    Cookie accessTokenCookie = tokenHelper.createAccessTokenCookie(newAccessToken);
+                    Cookie refreshTokenCookie = tokenHelper.createRefreshTokenCookie(refreshToken, userId); // ✅ 기존 refreshToken 유지
+
+                    response.addCookie(accessTokenCookie);
+                    response.addCookie(refreshTokenCookie);
+
+                    System.out.println("[AUTH] 🔄 accessToken 재발급 완료 (쿠키 기반)");
+                    authenticateUser(userId);
+                    chain.doFilter(request, response);
+                    return;
+                }
+
+
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "accessToken 만료 & refreshToken 없음 또는 불일치");
+                return;
+
             } catch (Exception e) {
-                System.out.println("[AUTH] ❌ 인증 실패: " + e.getMessage());
+                System.out.println("[AUTH] ❌ accessToken 파싱/검증 실패: " + e.getMessage());
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "accessToken 검증 실패");
+                return;
             }
         }
 
+        // ❌ accessToken 자체 없음 → 다음 필터로 넘김
         chain.doFilter(request, response);
+    }
+
+    private void authenticateUser(Long userId) {
+        UserDTO user = userService.findById(userId);
+        if (user != null) {
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            user, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+    }
+
+    private String getTokenFromCookies(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (name.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    // 🍪 로그 확인용
+    private void logTokensFromCookies(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            System.out.println("[DEBUG] 🍪 쿠키 없음");
+            return;
+        }
+
+        for (Cookie cookie : request.getCookies()) {
+            if ("accessToken".equals(cookie.getName())) {
+                System.out.println("[DEBUG] 🍪 accessToken 쿠키 값: " + cookie.getValue());
+            } else if ("refreshToken".equals(cookie.getName())) {
+                System.out.println("[DEBUG] 🍪 refreshToken 쿠키 값: " + cookie.getValue());
+            }
+        }
     }
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/security/jwt/JwtProvider.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/security/jwt/JwtProvider.java
@@ -19,7 +19,9 @@ public class JwtProvider {
     @Value("${jwt.secret}")
     private String secretKeyStr;
 
-    private static final long ACCESS_TOKEN_VALIDITY = 15 * 60 * 1000L;
+    @Value("${frontend.access-token-expiration-time}")
+    private long accessTokenExpirationTime;
+
     
     private SecretKey getSecretKey() {
     	byte[] keyBytes = Base64.getDecoder().decode(secretKeyStr);
@@ -30,7 +32,7 @@ public class JwtProvider {
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_VALIDITY))
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpirationTime))
                 .signWith(getSecretKey())
                 .compact();
     }
@@ -40,7 +42,7 @@ public class JwtProvider {
                 .setSubject(String.valueOf(userId))
                 .addClaims(claims)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_VALIDITY))
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpirationTime))
                 .signWith(getSecretKey())
                 .compact();
     }
@@ -54,5 +56,20 @@ public class JwtProvider {
                 .getSubject()
         );
     }
+    
+ // JwtProvider.java 내부에 추가
+    public boolean isTokenExpired(String token) {
+        try {
+            Date expiration = Jwts.parser()
+                    .setSigningKey(getSecretKey())
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getExpiration();
+            return expiration.before(new Date());
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
 
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/security/jwt/JwtReissueController.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/security/jwt/JwtReissueController.java
@@ -25,7 +25,7 @@ public class JwtReissueController {
     public ResponseEntity<?> reissue(@RequestHeader("Authorization") String accessTokenHeader,
                                      @RequestHeader("Refresh") String refreshToken) {
         String accessToken = accessTokenHeader.replace("Bearer ", "");
-
+        
         return refreshTokenService.reissue(refreshToken, accessToken)
             .map(newAccessToken -> ResponseEntity.ok(Map.of("accessToken", newAccessToken)))
             .orElseGet(() -> {

--- a/backend/demo/src/main/java/store/oneul/mvc/security/jwt/JwtReissueFilter.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/security/jwt/JwtReissueFilter.java
@@ -30,6 +30,7 @@ public class JwtReissueFilter extends OncePerRequestFilter {
 
         if (accessToken != null && refreshToken != null) {
             try {
+            	System.out.println("doFilterInternal 들어옴??");
                 jwtProvider.getUserIdFromToken(accessToken); // 정상 동작
             } catch (Exception ex) {
                 System.out.println("[FILTER] ⚠️ AccessToken expired or invalid. Attempting reissue.");

--- a/backend/demo/src/main/java/store/oneul/mvc/security/oauth/OAuth2SuccessHandler.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/security/oauth/OAuth2SuccessHandler.java
@@ -82,7 +82,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             boolean signupCompleted = Boolean.TRUE.equals(user.getSignupCompleted());
 
             Cookie accessTokenCookie = tokenHelper.createAccessTokenCookie(loginResult.getAccessToken());
-            Cookie refreshTokenCookie = tokenHelper.createRefreshTokenCookie(loginResult.getRefreshToken());
+            Cookie refreshTokenCookie = tokenHelper.createRefreshTokenCookie(loginResult.getRefreshToken(),user.getUserId());
 
             response.addCookie(accessTokenCookie);
             response.addCookie(refreshTokenCookie);

--- a/backend/demo/src/main/java/store/oneul/mvc/security/rtr/RefreshTokenDao.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/security/rtr/RefreshTokenDao.java
@@ -13,14 +13,17 @@ public class RefreshTokenDao  {
     private final RedisTemplate<String, String> redisTemplate;
     private static final String PREFIX = "RT:";
 
-//    // 저장
-//    public void save(String userId, String refreshToken, Duration expiration) {
-//        redisTemplate.opsForValue().set(PREFIX + userId, refreshToken, expiration);
-//    }
+    // 저장
+    public void save(String userId, String refreshToken, Duration expiration) {
+        redisTemplate.opsForValue().set(PREFIX + userId, refreshToken, expiration);
+    }
 
     // 조회
     public String findByUserId(String userId) {
-        return redisTemplate.opsForValue().get(PREFIX + userId);
+    	
+    	String r = redisTemplate.opsForValue().get(PREFIX + userId);
+    	System.out.println(r);
+        return r;
     }
 
     // 삭제

--- a/backend/demo/src/main/java/store/oneul/mvc/security/rtr/RefreshTokenService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/security/rtr/RefreshTokenService.java
@@ -19,13 +19,19 @@ public class RefreshTokenService {
 
     public String createAndSaveRefreshToken(Long userId) {
         String refreshToken = UUID.randomUUID().toString();
-        //refreshTokenRepository.save(String.valueOf(userId), refreshToken, REFRESH_TOKEN_EXPIRATION);
+        refreshTokenRepository.save(String.valueOf(userId), refreshToken, REFRESH_TOKEN_EXPIRATION);
+        System.out.println("Saving refresh token for userId: " + userId + " - Token: " + refreshToken);
+        System.out.println(1111);
         return refreshToken;
     }
-
+    
     public boolean validate(String userId, String providedToken) {
         String savedToken = refreshTokenRepository.findByUserId(userId);
         return savedToken != null && savedToken.equals(providedToken);
+    }
+    
+    public String findByUserId(long userId) {
+        return refreshTokenRepository.findByUserId(String.valueOf(userId));
     }
 
     public void delete(String userId) {
@@ -38,6 +44,7 @@ public class RefreshTokenService {
             String userIdStr = String.valueOf(userId);
 
             String saved = refreshTokenRepository.findByUserId(userIdStr);
+            System.out.println("[RTR] Checking saved token for userId = " + userIdStr + ": " + saved);
             if (!refreshToken.equals(saved)) {
                 System.out.println("[RTR] ❌ RefreshToken mismatch for userId = " + userIdStr);
                 return Optional.empty();
@@ -47,7 +54,7 @@ public class RefreshTokenService {
 
             refreshTokenRepository.delete(userIdStr);
             String newRefreshToken = UUID.randomUUID().toString();
-           // refreshTokenRepository.save(userIdStr, newRefreshToken, REFRESH_TOKEN_EXPIRATION);
+            refreshTokenRepository.save(userIdStr, newRefreshToken, REFRESH_TOKEN_EXPIRATION);
 
             System.out.println("[RTR] ✅ Access & Refresh Token reissued for userId = " + userIdStr);
 
@@ -57,4 +64,5 @@ public class RefreshTokenService {
             return Optional.empty();
         }
     }
+
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/security/token/TokenHelper.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/security/token/TokenHelper.java
@@ -1,34 +1,52 @@
 package store.oneul.mvc.security.token;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import lombok.RequiredArgsConstructor;
 import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import store.oneul.mvc.security.rtr.RefreshTokenService;
 
 
 @Component
 @RequiredArgsConstructor
+@Setter
+@ConfigurationProperties(prefix = "frontend")
 public class TokenHelper {
-    private final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
-    private final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
-    private final int ACCESS_TOKEN_EXPIRATION_TIME = 60 * 60; // 1시간
-    private final int REFRESH_TOKEN_EXPIRATION_TIME = 60 * 60 * 24 * 7; // 7일
-
+    private String accessTokenCookieName;
+    private String refreshTokenCookieName;
+    private int accessTokenExpirationTime;
+    private int refreshTokenExpirationTime;
+    private final RefreshTokenService refreshTokenService;
+ 
     public Cookie createAccessTokenCookie(String token) {
-        Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, token);
+        Cookie cookie = new Cookie(accessTokenCookieName, token);
         cookie.setHttpOnly(false);
         cookie.setSecure(false);
         cookie.setPath("/");
-        cookie.setMaxAge(ACCESS_TOKEN_EXPIRATION_TIME);
+        cookie.setMaxAge(accessTokenExpirationTime);
+        return cookie;
+    }
+    // Refresh Token 쿠키 생성
+    public Cookie createRefreshTokenCookie(String token, long userId) {
+        // Redis에서 저장된 refreshToken을 가져옵니다.
+        String refreshToken = refreshTokenService.findByUserId(userId);
+
+        if (refreshToken == null) {
+            // Redis에 refreshToken이 없다면 새로 생성 후 저장
+            refreshToken = refreshTokenService.createAndSaveRefreshToken(userId);
+        }
+
+        // 쿠키에 Redis에서 가져온 refreshToken을 설정
+        Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
+        cookie.setHttpOnly(false); // 보안을 강화하려면 true로 설정
+        cookie.setSecure(false); // HTTPS에서만 전송되도록 설정
+        cookie.setPath("/");
+        cookie.setMaxAge(refreshTokenExpirationTime);
+
         return cookie;
     }
 
-    public Cookie createRefreshTokenCookie(String token) {
-        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, token);
-        cookie.setHttpOnly(false);
-        cookie.setSecure(false);
-        cookie.setPath("/");
-        cookie.setMaxAge(REFRESH_TOKEN_EXPIRATION_TIME);
-        return cookie;
-    }
+
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/user/controller/UserController.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/user/controller/UserController.java
@@ -57,7 +57,7 @@ public class UserController {
         System.out.println("guestNo: " + guestNo);
         LoginResultDTO result = oauthService.guestLogin(guestNo);
         Cookie accessCookie = tokenHelper.createAccessTokenCookie(result.getAccessToken());
-        Cookie refreshCookie = tokenHelper.createRefreshTokenCookie(result.getRefreshToken());
+        Cookie refreshCookie = tokenHelper.createRefreshTokenCookie(result.getRefreshToken(), guestNo);
         System.out.println("accessCookie: " + accessCookie);
         System.out.println("refreshCookie: " + refreshCookie);
         response.addCookie(accessCookie);


### PR DESCRIPTION
## 개요

Resolves: #84

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

###작업 내용
1. accessToken / refreshToken 인증 흐름 리팩토링
- accessToken 만료 시 refreshToken 기반으로 재발급 후 쿠키에 재저장하는 흐름 구현
- JwtAuthenticationFilter에서 accessToken이 만료되었을 경우:
쿠키에서 refreshToken 추출
Redis의 토큰 값과 일치하는지 검증
accessToken을 새로 발급하여 쿠키에 저장

2. 쿠키 기반 인증 흐름 개선
- TokenHelper를 통해 accessToken / refreshToken 쿠키를 생성 및 재사용
- 기존 헤더 기반 인증을 제거하고 쿠키를 활용한 인증 흐름으로 전환

3. 만료 시간 application.properties 연동
- J- wtProvider의 accessToken 만료 시간을 하드코딩에서 frontend.access-token-expiration-time 프로퍼티로 수정
- 기존 상수 ACCESS_TOKEN_VALIDITY 제거

4. JWT 필터 내 디버깅 로깅 추가
- accessToken, refreshToken 쿠키 로그 출력 (logTokensFromCookies())
- 인증 성공/실패에 대한 로그 및 상태 코드 반환 처리 강화

## 공유사항 to 리뷰어

완벽실패했습니다... 절대 머지하지마세요.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
