### PR TITLE
[Feat] Toss 취소 실패 시 DLQ 적재 및 스케줄링 기반 환불 재시도 구현

### DIFF
--- a/backend/demo/src/main/java/store/oneul/mvc/payment/controller/PaymentController.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/controller/PaymentController.java
@@ -4,9 +4,14 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,8 +20,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.async.DeferredResult;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import store.oneul.mvc.challenge.dto.ChallengeDTO;
 import store.oneul.mvc.challenge.service.ChallengeService;
 import store.oneul.mvc.common.exception.InvalidParameterException;
@@ -25,9 +32,11 @@ import store.oneul.mvc.payment.dto.OrderIdResponse;
 import store.oneul.mvc.payment.dto.PaymentConfirmRequest;
 import store.oneul.mvc.payment.dto.PaymentResultResponse;
 import store.oneul.mvc.payment.dto.PaymentSessionDto;
+import store.oneul.mvc.payment.service.PaymentStatusService;
 import store.oneul.mvc.payment.usecase.PaymentUsecase;
 import store.oneul.mvc.user.dto.UserDTO;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/payments")
 @RequiredArgsConstructor
@@ -37,6 +46,7 @@ public class PaymentController {
 
     private final ChallengeService challengeService;
     private final PaymentUsecase paymentUsecase;
+    private final PaymentStatusService paymentStatusService;
     
     @Qualifier("jsonRedisTemplate")
     private final RedisTemplate<String, Object> jsonRedisTemplate;
@@ -88,6 +98,61 @@ public class PaymentController {
         PaymentResultResponse response = paymentUsecase.confirmPayment(loginUser.getUserId(), request);
         return ResponseEntity.ok(response);
     }
+    
+    @GetMapping("/result/{orderId}")
+    public DeferredResult<ResponseEntity<PaymentResultResponse>> getPaymentResult(@PathVariable String orderId) {
+        // 최대 3분 대기
+        DeferredResult<ResponseEntity<PaymentResultResponse>> output = new DeferredResult<>(180000L);
+
+        // 매 요청마다 독립 스케줄러 (부하 없으면 이 구조 OK)
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        final AtomicInteger checkCount = new AtomicInteger(0);
+
+        executor.scheduleAtFixedRate(() -> {
+            if (output.isSetOrExpired()) return;
+
+            try {
+                // 서비스로부터 상태 조회
+                PaymentResultResponse res = paymentStatusService.getResultByOrderId(orderId);
+
+                if (!"ROLLBACK_PENDING".equals(res.getStatus())) {
+                    log.info("✅ 최종 상태 도달 → 응답 반환 (orderId: {}, status: {})", orderId, res.getStatus());
+                    output.setResult(ResponseEntity.ok(res));
+                    executor.shutdownNow();
+                    return;
+                }
+
+                // 최대 3분 동안 polling (1초마다)
+                if (checkCount.incrementAndGet() >= 180) {
+                    log.warn("⚠️ ROLLBACK_PENDING 유지 → fallback 응답 (orderId: {})", orderId);
+                    output.setResult(ResponseEntity.ok(res)); // 팬딩 그대로 반환
+                    executor.shutdownNow();
+                } else {
+                    log.debug("⏳ 환불 대기 중... (orderId: {}, retry: {})", orderId, checkCount.get());
+                }
+
+            } catch (Exception e) {
+                log.error("❌ 상태 조회 중 예외 발생 (orderId: {})", orderId, e);
+                output.setResult(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body(PaymentResultResponse.systemError(orderId)));
+                executor.shutdownNow();
+            }
+
+        }, 0, 1, TimeUnit.SECONDS);
+
+        // 종료 이벤트 핸들링
+        output.onCompletion(executor::shutdownNow);
+        output.onTimeout(executor::shutdownNow);
+        output.onError(e -> {
+            log.error("❌ 롱폴링 처리 중 예외", e);
+            output.setResult(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(PaymentResultResponse.systemError(orderId)));
+            executor.shutdownNow();
+        });
+
+        return output;
+    }
+
 
 
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dao/PaymentDAO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dao/PaymentDAO.java
@@ -2,6 +2,7 @@ package store.oneul.mvc.payment.dao;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import store.oneul.mvc.payment.dto.CancelFailLogDTO;
 import store.oneul.mvc.payment.dto.PaymentDTO;
 import store.oneul.mvc.payment.dto.RefundReceiptDTO;
 
@@ -12,4 +13,12 @@ public interface PaymentDAO {
     int insertPayment(PaymentDTO dto);
     
     int insertRefundReceipt(RefundReceiptDTO receipt);
+    
+    int insertCancelFailLog(CancelFailLogDTO dto);
+    
+    Long findIdByOrderId(String orderId);
+    
+    RefundReceiptDTO findRefundReceiptByOrderId(String orderId);
+    
+    CancelFailLogDTO findCancelFailLogByOrderId(String orderId);
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dto/CancelFailLogDTO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dto/CancelFailLogDTO.java
@@ -1,0 +1,37 @@
+package store.oneul.mvc.payment.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import store.oneul.mvc.payment.enums.RefundReason;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class CancelFailLogDTO {
+    private Long id;
+    private Long paymentId; // Optional
+    private String orderId;
+    private String paymentKey;
+    private Long userId;
+    private Long challengeId;
+    private int amount;
+
+    private String type; // USER_CANCEL, AUTO_REFUND, COMPENSATION
+    private String errorStatus; // 예: "DLQ_RETRY_3_FAILED"
+    private String reason;
+    private String manualStatus; // WAITING_FORM / FORM_SUBMITTED
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    
+    public TossConfirmResponse toTossConfirmResponse() {
+        return TossConfirmResponse.builder()
+                .orderId(orderId)
+                .paymentKey(paymentKey)
+                .amount(amount)
+                .approvedAt(createdAt != null ? createdAt.toString() : null)
+                .build();
+    }
+
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dto/CancelRetryPayload.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dto/CancelRetryPayload.java
@@ -1,0 +1,51 @@
+package store.oneul.mvc.payment.dto;
+
+import lombok.Data;
+import store.oneul.mvc.payment.enums.RefundReason;
+import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
+
+@Data
+public class CancelRetryPayload {
+    private Long userId;
+    private Long challengeId;
+    private String orderId;
+    private String paymentKey;
+    private int amount;
+    private String refundType;
+    private int retry;
+    private Long paymentId; // optional
+
+    //  paymentId가 없는 경우 (TX_FAIL) : 트랜잭션 실패 시
+    public static CancelRetryPayload of(PaymentConfirmedEvent event, RefundReason reason, int retry) {
+        CancelRetryPayload payload = new CancelRetryPayload();
+        payload.setUserId(event.getUserId());
+        payload.setChallengeId(event.getChallengeId());
+        payload.setOrderId(event.getOrderId());
+        payload.setPaymentKey(event.getPaymentKey());
+        payload.setAmount(event.getAmount());
+        payload.setRetry(retry);
+        payload.setRefundType(reason.name());
+        payload.setPaymentId(null);
+        return payload;
+    }
+    
+    // paymentId가 있는 경우 (USER_CANCEL, CHALLENGE_SUCCESS)
+    public static CancelRetryPayload ofWithPaymentId(
+            PaymentConfirmedEvent event,
+            RefundReason reason,
+            int retry,
+            Long paymentId
+    ) {
+        CancelRetryPayload payload = new CancelRetryPayload();
+        payload.setUserId(event.getUserId());
+        payload.setChallengeId(event.getChallengeId());
+        payload.setOrderId(event.getOrderId());
+        payload.setPaymentKey(event.getPaymentKey());
+        payload.setAmount(event.getAmount());
+        payload.setRetry(retry);
+        payload.setRefundType(reason.name());
+        payload.setPaymentId(paymentId); // 명시적으로 전달받은 ID
+        return payload;
+    }
+
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dto/PaymentResultResponse.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dto/PaymentResultResponse.java
@@ -52,7 +52,7 @@ public class PaymentResultResponse {
                 .build();
     }
 
-    // ✅ TossCancel 실패 → 수동 환불 유도
+    // ✅ TossCancel 실패 → 최종 실패 -> 수동 환불 유도
     public static PaymentResultResponse manualRefundRequired(TossConfirmResponse res) {
         return PaymentResultResponse.builder()
                 .status("ROLLBACK_FAILED")
@@ -64,4 +64,28 @@ public class PaymentResultResponse {
                 .approvedAt(res.getApprovedAt())
                 .build();
     }
+    
+    // ✅ TossCancel 실패 → 스케줄링 중 -> 팬딩 상태
+    public static PaymentResultResponse refundPending(TossConfirmResponse res) {
+        return PaymentResultResponse.builder()
+                .status("ROLLBACK_PENDING")
+                .message("환불 처리 중입니다. 잠시 후 다시 확인해주세요.")
+                .manualRefundRequired(false)
+                .orderId(res.getOrderId())
+                .paymentKey(res.getPaymentKey())
+                .paidAmount(res.getAmount())
+                .approvedAt(res.getApprovedAt())
+                .build();
+    }
+    
+    // ✅ DLQ 3회 시도 후에도 아무 결과 없음 → 시스템 예외 상태
+    public static PaymentResultResponse systemError(String orderId) {
+        return PaymentResultResponse.builder()
+                .status("SYSTEM_ERROR")
+                .message("시스템 문제로 인해 환불 상태를 확인할 수 없습니다. 고객센터로 문의해 주세요.")
+                .manualRefundRequired(true)
+                .orderId(orderId)
+                .build();
+    }
+
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dto/RefundReceiptDTO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dto/RefundReceiptDTO.java
@@ -15,4 +15,18 @@ public class RefundReceiptDTO {
     private LocalDateTime refundedAt;
     private String transactionId;     // Toss 기준: receiptKey or transaction id
     private String note;
+    
+    private String orderId;
+    private String paymentKey;
+    
+    // paymentKey 있을 경우 환불 
+    public TossConfirmResponse toTossConfirmResponse() {
+        return TossConfirmResponse.builder()
+                .orderId(orderId) // 또는 별도로 관리되는 orderId가 있으면 그걸 넣어야 함
+                .paymentKey(paymentKey) // Toss 기준 key가 없다면 적절히 대응
+                .amount(refundAmount)
+                .approvedAt(refundedAt != null ? refundedAt.toString() : null)
+                .build();
+    }
+
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/enums/RefundReason.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/enums/RefundReason.java
@@ -1,7 +1,26 @@
 package store.oneul.mvc.payment.enums;
 
 public enum RefundReason {
-    TX_FAIL,             // 트랜잭션 롤백 시 자동 환불
-    USER_CANCEL,         // 유저가 자발적으로 환불 요청
-    CHALLENGE_SUCCESS    // 챌린지 성공 → 세금 제외 환급
+    TX_FAIL("AUTO_REFUND"),
+    USER_CANCEL("USER_CANCEL"),
+    CHALLENGE_SUCCESS("COMPENSATION");
+
+    private final String dbValue;
+
+    RefundReason(String dbValue) {
+        this.dbValue = dbValue;
+    }
+
+    public String toDbValue() {
+        return dbValue;
+    }
+
+    public static RefundReason fromDbValue(String dbValue) {
+        for (RefundReason reason : values()) {
+            if (reason.dbValue.equalsIgnoreCase(dbValue)) {
+                return reason;
+            }
+        }
+        throw new IllegalArgumentException("Unknown DB refund type: " + dbValue);
+    }
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/scheduler/ScheduledCancelRetryWorker.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/scheduler/ScheduledCancelRetryWorker.java
@@ -1,0 +1,26 @@
+package store.oneul.mvc.payment.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import store.oneul.mvc.payment.service.CancelRetryService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScheduledCancelRetryWorker {
+
+    private final CancelRetryService cancelRetryService;
+
+    // 5초마다 재시도
+    @Scheduled(fixedDelay = 5000)
+    public void retryCancelFromDLQ() {
+        try {
+            cancelRetryService.retryOnce();
+        } catch (Exception e) {
+            log.error("❌ DLQ 재시도 실패", e);
+        }
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/CancelDLQService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/CancelDLQService.java
@@ -1,0 +1,8 @@
+package store.oneul.mvc.payment.service;
+
+import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
+
+public interface CancelDLQService {
+
+	 public void pushToQueue(PaymentConfirmedEvent event);
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/CancelDLQServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/CancelDLQServiceImpl.java
@@ -1,0 +1,37 @@
+package store.oneul.mvc.payment.service;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import store.oneul.mvc.payment.dto.CancelRetryPayload;
+import store.oneul.mvc.payment.enums.RefundReason;
+import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CancelDLQServiceImpl implements CancelDLQService {
+
+    private static final String DLQ_KEY = "payment:cancel:queue";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void pushToQueue(PaymentConfirmedEvent event) {
+        try {
+            CancelRetryPayload payload = CancelRetryPayload.of(event, RefundReason.TX_FAIL, 0);
+
+            String json = objectMapper.writeValueAsString(payload);
+            redisTemplate.opsForList().rightPush(DLQ_KEY, json);
+            log.warn("✅ DLQ 적재 완료 - orderId: {}, retry: {}", payload.getOrderId(), payload.getRetry());
+
+        } catch (Exception e) {
+            log.error("🔥 DLQ Redis 적재 실패 - orderId: {}", event.getOrderId(), e);
+        }
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/CancelRetryService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/CancelRetryService.java
@@ -1,0 +1,5 @@
+package store.oneul.mvc.payment.service;
+
+public interface CancelRetryService {
+    void retryOnce(); // DLQ에서 1개 꺼내서 재시도
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/CancelRetryServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/CancelRetryServiceImpl.java
@@ -1,0 +1,102 @@
+package store.oneul.mvc.payment.service;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import store.oneul.mvc.payment.dao.PaymentDAO;
+import store.oneul.mvc.payment.dto.CancelFailLogDTO;
+import store.oneul.mvc.payment.dto.CancelRetryPayload;
+import store.oneul.mvc.payment.enums.RefundReason;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CancelRetryServiceImpl implements CancelRetryService {
+
+    private static final String DLQ_KEY = "payment:cancel:queue";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private final TossCancelService tossCancelService;
+    private final RefundReceiptService refundReceiptService;
+    private final PaymentDAO paymentDAO;
+    
+
+    @Override
+    public void retryOnce() {
+        String json = redisTemplate.opsForList().leftPop(DLQ_KEY);
+        if (json == null) return;
+
+        try {
+            CancelRetryPayload payload = objectMapper.readValue(json, CancelRetryPayload.class);
+            log.warn("🔁 DLQ 재시도 시작 - orderId: {}, retry: {}", payload.getOrderId(), payload.getRetry());
+
+            // TossCancel 재시도
+            int refundAmount = tossCancelService.cancel(payload, RefundReason.valueOf(payload.getRefundType()));
+
+            // 환불 내역 저장
+            refundReceiptService.recordRetryRefund(payload, refundAmount, "DLQ 재시도 환불 성공");
+
+            log.info("✅ DLQ 재시도 성공 - orderId: {}", payload.getOrderId());
+
+        } catch (Exception e) {
+            log.error("❌ DLQ 재시도 실패", e);
+
+            try {
+                CancelRetryPayload failed = objectMapper.readValue(json, CancelRetryPayload.class);
+                int nextRetry = failed.getRetry() + 1;
+
+                if (nextRetry >= 3) {
+                    log.error("🔥 DLQ 3회 실패 - 수동 환불 전환 필요 (orderId: {})", failed.getOrderId());
+
+                    // 1. paymentId 조회
+                    Long paymentId = null;
+                    try {
+                        paymentId = paymentDAO.findIdByOrderId(failed.getOrderId());
+                    } catch (Exception ex) {
+                        log.warn("⚠️ paymentId 조회 실패 - orderId: {}, 예외: {}", failed.getOrderId(), ex.getMessage());
+                    }
+
+                    // 2. RefundReason Enum 변환
+                    RefundReason reason;
+                    try {
+                        reason = RefundReason.valueOf(failed.getRefundType());
+                    } catch (IllegalArgumentException ie) {
+                        log.warn("⚠️ RefundReason 변환 실패: {}, 기본값 TX_FAIL 사용", failed.getRefundType());
+                        reason = RefundReason.TX_FAIL;
+                    }
+
+                    // 3. CancelFailLogDTO 생성
+                    CancelFailLogDTO logDTO = CancelFailLogDTO.builder()
+                    	    .orderId(failed.getOrderId())
+                    	    .paymentKey(failed.getPaymentKey())
+                    	    .userId(failed.getUserId())
+                    	    .challengeId(failed.getChallengeId())
+                    	    .amount(failed.getAmount())
+                    	    .type(reason.toDbValue())  // 💡 여기에 적용
+                    	    .errorStatus("DLQ_RETRY_3_FAILED")
+                    	    .reason("DLQ 재시도 3회 실패")
+                    	    .manualStatus("WAITING_FORM")
+                    	    .build();
+
+
+                    paymentDAO.insertCancelFailLog(logDTO);
+                }
+                else {
+                    failed.setRetry(nextRetry);
+                    String retryJson = objectMapper.writeValueAsString(failed);
+                    redisTemplate.opsForList().rightPush(DLQ_KEY, retryJson);
+                    log.warn("🔁 DLQ 재적재 완료 - orderId: {}, retry: {}", failed.getOrderId(), nextRetry);
+                }
+
+            } catch (Exception retryEx) {
+                log.error("🔥 DLQ 재적재 실패 - orderId: {}", json, retryEx);
+            }
+        }
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/CompensationServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/CompensationServiceImpl.java
@@ -1,9 +1,9 @@
 package store.oneul.mvc.payment.service;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import store.oneul.mvc.payment.enums.RefundReason;
 import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
 
@@ -14,7 +14,8 @@ public class CompensationServiceImpl implements CompensationService {
 
     private final TossCancelService tossCancelService;
     private final RefundReceiptService refundReceiptService;
-
+    private final CancelDLQService cancelDLQService;
+    
     @Override
     public void handleConfirmFail(PaymentConfirmedEvent event) {
         try {
@@ -28,6 +29,7 @@ public class CompensationServiceImpl implements CompensationService {
         } catch (Exception e) {
             log.error("❌ Toss Cancel 실패 - DLQ 적재 예정", e);
             // TODO: Redis DLQ 적재
+            cancelDLQService.pushToQueue(event);
         }
     }
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/PaymentStatusService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/PaymentStatusService.java
@@ -1,0 +1,7 @@
+package store.oneul.mvc.payment.service;
+
+import store.oneul.mvc.payment.dto.PaymentResultResponse;
+
+public interface PaymentStatusService {
+    PaymentResultResponse getResultByOrderId(String orderId);
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/PaymentStatusServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/PaymentStatusServiceImpl.java
@@ -1,0 +1,33 @@
+package store.oneul.mvc.payment.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import store.oneul.mvc.payment.dao.PaymentDAO;
+import store.oneul.mvc.payment.dto.CancelFailLogDTO;
+import store.oneul.mvc.payment.dto.PaymentResultResponse;
+import store.oneul.mvc.payment.dto.RefundReceiptDTO;
+import store.oneul.mvc.payment.dto.TossConfirmResponse;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentStatusServiceImpl implements PaymentStatusService {
+
+    private final PaymentDAO paymentDAO;
+
+    @Override
+    public PaymentResultResponse getResultByOrderId(String orderId) {
+        RefundReceiptDTO receipt = paymentDAO.findRefundReceiptByOrderId(orderId);
+        if (receipt != null) {
+            return PaymentResultResponse.refunded(receipt.toTossConfirmResponse(), receipt.getRefundAmount(), receipt.getRefundedAt().toString());
+        }
+
+        CancelFailLogDTO failLog = paymentDAO.findCancelFailLogByOrderId(orderId);
+        if (failLog != null) {
+            return PaymentResultResponse.manualRefundRequired(failLog.toTossConfirmResponse());
+        }
+
+        // fallback
+        return PaymentResultResponse.systemError(orderId);
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/RefundReceiptService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/RefundReceiptService.java
@@ -1,11 +1,13 @@
 package store.oneul.mvc.payment.service;
 
+import store.oneul.mvc.payment.dto.CancelRetryPayload;
 import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
 
 public interface RefundReceiptService {
 
     void recordAutoRefund(PaymentConfirmedEvent event, int refundAmount, String reason);
-    
+    void recordRetryRefund(CancelRetryPayload payload, int refundAmount, String reason);
+
     // 필요 시 수동 환불 확장도 가능
     // void recordManualRefund(...);
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/RefundReceiptServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/RefundReceiptServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import store.oneul.mvc.payment.dao.PaymentDAO;
+import store.oneul.mvc.payment.dto.CancelRetryPayload;
 import store.oneul.mvc.payment.dto.RefundReceiptDTO;
 import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
 
@@ -32,4 +33,22 @@ public class RefundReceiptServiceImpl implements RefundReceiptService {
         paymentDAO.insertRefundReceipt(receipt);
         log.info("💾 환불 내역 저장 완료 (userId: {}, amount: {})", event.getUserId(), refundAmount);
     }
+    
+    @Override
+    public void recordRetryRefund(CancelRetryPayload payload, int refundAmount, String reason) {
+        RefundReceiptDTO receipt = new RefundReceiptDTO();
+        receipt.setUserId(payload.getUserId());
+        receipt.setChallengeId(payload.getChallengeId());
+        receipt.setPaymentId(payload.getPaymentId()); // TX_FAIL은 null, 그 외에는 존재
+        receipt.setRefundMethod("TOSS_AUTO");
+        receipt.setRefundAmount(refundAmount);
+        receipt.setRefundedAt(LocalDateTime.now());
+        receipt.setTransactionId("TOSS_CANCEL_" + payload.getPaymentKey());
+        receipt.setNote("orderId: " + payload.getOrderId() + " / " + reason);
+
+        paymentDAO.insertRefundReceipt(receipt);
+        log.info("💾 DLQ 환불 저장 완료 (userId: {}, retry: {}, amount: {})",
+                 payload.getUserId(), payload.getRetry(), refundAmount);
+    }
+
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/TossCancelService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/TossCancelService.java
@@ -1,9 +1,12 @@
 package store.oneul.mvc.payment.service;
 
+import store.oneul.mvc.payment.dto.CancelRetryPayload;
 import store.oneul.mvc.payment.enums.RefundReason;
 import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
 
 public interface TossCancelService {
 
 	public int cancel(PaymentConfirmedEvent event, RefundReason reason);
+	public int cancel(CancelRetryPayload payload, RefundReason reason);
+
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/TossCancelServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/TossCancelServiceImpl.java
@@ -2,14 +2,15 @@ package store.oneul.mvc.payment.service;
 
 import java.time.LocalDate;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import store.oneul.mvc.challenge.dao.ChallengeDAO;
 import store.oneul.mvc.challenge.dto.ChallengeDTO;
-import store.oneul.mvc.payment.client.TossClient;
 import store.oneul.mvc.payment.calculator.RefundAmountCalculator;
+import store.oneul.mvc.payment.client.TossClient;
+import store.oneul.mvc.payment.dto.CancelRetryPayload;
 import store.oneul.mvc.payment.dto.TossCancelRequest;
 import store.oneul.mvc.payment.enums.RefundReason;
 import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
@@ -38,5 +39,24 @@ public class TossCancelServiceImpl implements TossCancelService {
         log.info("✅ Toss 결제 취소 성공 (paymentKey: {}, refundAmount: {})", event.getPaymentKey(), refundAmount);
         return refundAmount;
     }
+    
+    @Override
+    public int cancel(CancelRetryPayload payload, RefundReason reason) {
+        ChallengeDTO challenge = challengeDAO.getChallengeById(payload.getChallengeId());
+
+        int refundAmount = RefundAmountCalculator.calculate(
+            challenge.getEntryFee(),
+            challenge.getStartDate(),
+            LocalDate.now(),
+            reason
+        );
+
+        TossCancelRequest request = new TossCancelRequest(refundAmount, "자동 환불 처리: " + reason.name());
+        tossClient.cancel(payload.getPaymentKey(), request);
+
+        log.info("✅ Toss 결제 취소 성공 (paymentKey: {}, refundAmount: {})", payload.getPaymentKey(), refundAmount);
+        return refundAmount;
+    }
+
 }
 

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/usecase/PaymentUsecase.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/usecase/PaymentUsecase.java
@@ -70,7 +70,7 @@ public class PaymentUsecase {
                 log.error("❌ TossCancel 또는 환불기록 실패 → 수동 환불 전환 필요", ex);
 
                 // 9. 수동 환불 응답 반환
-                return PaymentResultResponse.manualRefundRequired(tossResponse);
+                return PaymentResultResponse.refundPending(tossResponse);
             }
         }
     }

--- a/backend/demo/src/main/resources/mappers/PaymentMapper.xml
+++ b/backend/demo/src/main/resources/mappers/PaymentMapper.xml
@@ -12,22 +12,9 @@
         )
     </select>
     
-        <insert id="insertPayment" parameterType="PaymentDTO">
-        INSERT INTO payment (
-            user_id,
-            challenge_id,
-            order_id,
-            payment_key,
-            amount,
-            status
-        ) VALUES (
-            #{userId},
-            #{challengeId},
-            #{orderId},
-            #{paymentKey},
-            #{amount},
-            #{status}
-        )
+    <insert id="insertPayment" parameterType="PaymentDTO">
+        INSERT INTO payment (user_id, challenge_id, order_id, payment_key, amount, status ) 
+        VALUES ( #{userId}, #{challengeId}, #{orderId}, #{paymentKey}, #{amount}, #{status})
     </insert>
     
      <insert id="insertRefundReceipt" parameterType="RefundReceiptDTO">
@@ -53,6 +40,78 @@
 	      #{note}
 	    )
   	</insert>
+  	
+  	<insert id="insertCancelFailLog" parameterType="CancelFailLogDTO">
+		INSERT INTO cancel_fail_log (
+            payment_id,
+            order_id,
+            payment_key,
+            user_id,
+            challenge_id,
+            amount,
+            type,
+            error_status,
+            reason,
+            manual_status
+        ) VALUES (
+            #{paymentId},
+            #{orderId},
+            #{paymentKey},
+            #{userId},
+            #{challengeId},
+            #{amount},
+            #{type},
+            #{errorStatus},
+            #{reason},
+            #{manualStatus}
+        )
+	    
+	</insert>
+  	
+  	<select id="findIdByOrderId" parameterType="string" resultType="long">
+	    SELECT id
+	    FROM payment
+	    WHERE order_id = #{orderId}
+	</select>
+	
+	<!-- 환불 영수증 + 결제 테이블 조인 -->
+	<select id="findRefundReceiptByOrderId" resultType="RefundReceiptDTO">
+        SELECT
+            r.payment_id,
+            r.cancel_fail_log_id,
+            r.user_id,
+            r.challenge_id,
+            r.refund_method,
+            r.refund_amount,
+            r.refunded_at,
+            r.transaction_id,
+            r.note,
+            p.order_id,
+            p.payment_key
+        FROM refund_receipt r
+        JOIN payment p ON r.payment_id = p.id
+        WHERE p.order_id = #{orderId}
+    </select>
+    
+        <!-- 취소 실패 로그 단독 조회 (orderId 기준) -->
+    <select id="findCancelFailLogByOrderId" resultType="store.oneul.mvc.payment.dto.CancelFailLogDTO">
+        SELECT
+            c.id,
+            c.payment_id,
+            c.order_id,
+            c.payment_key,
+            c.user_id,
+            c.challenge_id,
+            c.amount,
+            c.type,
+            c.error_status,
+            c.reason,
+            c.manual_status,
+            c.created_at,
+            c.updated_at
+        FROM cancel_fail_log c
+        WHERE c.order_id = #{orderId}
+    </select>
     
     
 </mapper>


### PR DESCRIPTION
## 개요

Resolves: #203 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용
### 🔁 DLQ 및 환불 재시도 흐름

- `CancelDLQServiceImpl`
  - TossCancel 실패 시 DLQ(`payment:cancel:queue`)에 JSON 메시지 적재
- `CancelRetryServiceImpl`
  - Redis로부터 실패 메시지 pop 후 TossCancel 재시도
  - 성공 시 → `refund_receipt` 저장
  - 실패 시 → retry 증가 후 재적재
  - 3회 실패 시 → `cancel_fail_log` 테이블 insert
- `ScheduledCancelRetryWorker`
  - 5초마다 재시도 트리거 수행

---

### ✅ 응답 구조 변경

- `PaymentResultResponse`
  - `ROLLBACK_PENDING` 응답 타입 추가
  - `ROLLBACK_REFUNDED` (자동 환불 완료), `ROLLBACK_FAILED` (3회 실패) 기존 유지
- `PaymentUsecase`
  - TossCancel 실패 시 `ROLLBACK_PENDING` 반환


---

### 📦 관련 클래스 / 리팩토링

| 변경 사항 | 설명 |
|-----------|------|
| `CancelRetryPayload` | DLQ 메시지 구조 정의 |
| `RefundReason` | enum + DB 대응 메서드 (`toDbValue`, `fromDbValue`) |
| `CancelFailLogDTO` | 3회 실패 시 DB insert용 DTO |
| `PaymentDAO` | `findIdByOrderId`, `insertCancelFailLog` 메서드 추가 |
| `RefundReceiptServiceImpl` | 재시도 성공 시 환불 기록 저장 |

---

- `/api/payments/result/{orderId}` GET API 구현 (DeferredResult 기반 롱폴링 응답)
- 1초마다 결제 상태 확인 → 최대 3분 대기
- `PaymentResultResponse`에 SYSTEM_ERROR 상태 추가
- `RefundReceiptDTO`, `CancelFailLogDTO` → toTossConfirmResponse() 추가
- `PaymentStatusServiceImpl` → 환불 성공/실패/미처리 분기 구현
- `PaymentDAO` 및 Mapper 쿼리 구현 (payment 조인 포함)
- 롱폴링 중 예외 및 타임아웃 발생 시 graceful fallback 처리

