### PR TITLE
[Feat] 비로그인 유저 제한을 위한 ProtectedLayout 구현 

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import RegistPage from "@components/regist/RegistPage";
 import { useSocketStore } from "@stores/socketStore";
 import { useUserStore } from "@stores/userStore";
 import { useEffect } from "react";
-import { Route, Routes } from "react-router";
+import { Route, Routes } from "react-router-dom";
 import "@/App.css";
 import "@/chart";
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import ChallengePaymentPage from "@components/payment/ChallengePaymentPage";
 import PaymentSuccessPage from "@components/payment/PaymentSuccessPage";
 import PaymentFailPage from "@components/payment/PaymentFailPage";
 import MyPage from "@components/mypage/MyPage";
+import ProtectedLayout from "./layouts/ProtectedLayout";
 
 function App() {
   const { user } = useUserStore();
@@ -126,26 +127,29 @@ function App() {
         {/* MainLayout이 필요한 라우트들 */}
         <Route element={<MainLayout />}>
           <Route path="/" element={<Home />} />
-          <Route
-            path="/challenge/:challengeId"
-            element={<ChallengeDetailPage />}
-          />
-          <Route path="/challenge/detail" element={<ChallengeDetailPage />} />
           <Route path="/challenge/search" element={<ChallengeSearchPage />} />
-          <Route path="/challenge/create" element={<ChallengeCreatePage />} />
-          <Route path="/mypage" element={<MyPage />} />
+          <Route element={<ProtectedLayout />}>
+            <Route path="/challenge/create" element={<ChallengeCreatePage />} />
+            <Route
+              path="/challenge/:challengeId"
+              element={<ChallengeDetailPage />}
+            />
+            <Route path="/mypage" element={<MyPage />} />
+          </Route>
         </Route>
 
         {/* MainLayout이 필요없는 라우트들 */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<RegistPage />} />
         <Route path="/oauth/redirect" element={<OAuthRedirectPage />} />
-        <Route
-          path="challenge/:challengeId/order"
-          element={<ChallengePaymentPage />}
-        />
-        <Route path="/payment/success" element={<PaymentSuccessPage />} />
-        <Route path="/payment/fail" element={<PaymentFailPage />} />
+        <Route element={<ProtectedLayout />}>
+          <Route
+            path="challenge/:challengeId/order"
+            element={<ChallengePaymentPage />}
+          />
+          <Route path="/payment/success" element={<PaymentSuccessPage />} />
+          <Route path="/payment/fail" element={<PaymentFailPage />} />
+        </Route>
       </Routes>
     </div>
   );

--- a/frontend/src/components/login/LoginPage.tsx
+++ b/frontend/src/components/login/LoginPage.tsx
@@ -1,9 +1,21 @@
 import Header from "@components/common/Header";
 import Logo from "@components/common/Logo";
 import OAuthBtn from "@components/login/OAuthBtn";
-import GuestLoginBtn from "@components/login/GuestLoginBtn";
+import { useLocation } from "react-router";
+import { useEffect } from "react";
+import Toast from "../Toast/Toast";
 
 function LoginPage() {
+  const location = useLocation();
+  const state = location.state as { showAuthToast?: boolean };
+
+  useEffect(() => {
+    if (state?.showAuthToast) {
+      Toast.info("로그인이 필요한 페이지입니다");
+      window.history.replaceState({}, "");
+    }
+  }, [state]);
+
   return (
     <div className="h-full w-full bg-gradient-to-bl from-[#21414F] via-[#10212b] to-[#17171C]">
       <Header left={<Logo />} center={<></>} right={<></>} />

--- a/frontend/src/layouts/ProtectedLayout.tsx
+++ b/frontend/src/layouts/ProtectedLayout.tsx
@@ -1,8 +1,16 @@
 import { useUserStore } from "@/stores/userStore";
-import { Navigate, Outlet, useLocation } from "react-router";
+import { FiLoader } from "react-icons/fi";
+import { Navigate, Outlet } from "react-router-dom";
 
 export default function ProtectedLayout() {
-  const { user } = useUserStore();
+  const { user, isInitializing } = useUserStore();
+  if (isInitializing) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <FiLoader className="animate-spin text-3xl text-gray-500" />
+      </div>
+    );
+  }
   if (!user) {
     return <Navigate to="/login" replace state={{ showAuthToast: true }} />;
   }

--- a/frontend/src/layouts/ProtectedLayout.tsx
+++ b/frontend/src/layouts/ProtectedLayout.tsx
@@ -1,0 +1,10 @@
+import { useUserStore } from "@/stores/userStore";
+import { Navigate, Outlet, useLocation } from "react-router";
+
+export default function ProtectedLayout() {
+  const { user } = useUserStore();
+  if (!user) {
+    return <Navigate to="/login" replace state={{ showAuthToast: true }} />;
+  }
+  return <Outlet />;
+}

--- a/frontend/src/stores/userStore.tsx
+++ b/frontend/src/stores/userStore.tsx
@@ -14,6 +14,7 @@ interface UserStore {
   user: User | null;
   accessToken: string | null;
   setUser: (user: User, accessToken: string) => void;
+  isInitializing: boolean;
   logout: () => void;
   initializeFromToken: () => void;
 }
@@ -22,6 +23,7 @@ export const useUserStore = create<UserStore>((set, get) => ({
   user: null,
   accessToken: null,
   setUser: (user, accessToken) => set({ user, accessToken }),
+  isInitializing: true,
   logout: () => {
     set({ user: null, accessToken: null });
   },
@@ -42,5 +44,6 @@ export const useUserStore = create<UserStore>((set, get) => ({
         set({ user: null, accessToken: null });
       }
     }
+    set({ isInitializing: false });
   },
 }));


### PR DESCRIPTION
## 개요

Resolves: #215 
## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 작업 내용

- ProtectedLayout 구현 및 적용 
- auth 권한으로 리다이렉트된 유저는 로그인 페이지에서 toast 안내 (로그인 권한 필요 안내) 
- userStore 내에 isInitializing 플래그 추가 

## 스크린샷

![login_auth](https://github.com/user-attachments/assets/0d5d0f37-10d5-4491-b260-7e7ed748d2c3)


