### PR TITLE
[Fix] 챌린지 디테일 액티브 탭 이슈, 피드 체크 pending->approved 오류, 결제 오류 수정 

### DIFF
--- a/backend/demo/src/main/resources/mappers/PaymentMapper.xml
+++ b/backend/demo/src/main/resources/mappers/PaymentMapper.xml
@@ -5,7 +5,7 @@
 
 <mapper namespace="store.oneul.mvc.payment.dao.PaymentDAO">
 
-    <select id="existsByPaymentKey" parameterType="string" resultType="boolean">
+    <select id="existsByPaymentKey" parameterType="String" resultType="boolean">
         SELECT EXISTS (
             SELECT * FROM payment
             WHERE payment_key = #{paymentKey}

--- a/frontend/src/components/challengeDetail/ChallengeDetailPage.tsx
+++ b/frontend/src/components/challengeDetail/ChallengeDetailPage.tsx
@@ -38,6 +38,7 @@ function ChallengeDetailPage() {
       Toast.caution("아직 시작하지 않은 챌린지입니다.");
       hasShownToast.current = true;
     }
+    setActiveTab("challenge"); // 내부 액티브 탭 상태 초기화
   }, [challenge]);
 
   const renderContent = () => {

--- a/frontend/src/components/challengeDetail/ChallengeStatus.tsx
+++ b/frontend/src/components/challengeDetail/ChallengeStatus.tsx
@@ -60,9 +60,10 @@ function ChallengeStatus({
           </span>
         </p>
         <p>
-          챌린지 종료일까지 {elapsedDays > 0 ? elapsedDays : 0}일 중<br />
+          챌린지 종료일까지 {elapsedDays > 0 ? elapsedDays : 0}일,
+          <br />
           <span className="text-primary-purple-100 font-medium">
-            {goal - success > 0 ? goal - success : 0}일 남았어요!
+            달성까지 {goal - success > 0 ? goal - success : 0}번 남았어요!
           </span>
         </p>
       </div>

--- a/frontend/src/components/challengeDetail/ChellengeDetail.tsx
+++ b/frontend/src/components/challengeDetail/ChellengeDetail.tsx
@@ -37,11 +37,11 @@ function ChallengeDetail({ data }: ChallengeDetailProps) {
         <div className="mt-1 flex items-center gap-2">
           <h3 className="text-xl font-bold text-gray-200">{name}</h3>
           <button
-            onClick={() => {
-              /** TODO: 모달 등록 */
-            }}
-            className="flex cursor-pointer items-center gap-1 p-1 text-gray-500 hover:text-gray-200"
-            aria-label="인원수 보기"
+            // onClick={() => {
+            //   /** TODO: 모달 등록 */
+            // }}
+            className="flex items-center gap-1 p-1 text-gray-500"
+            // aria-label="인원수 보기"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/challengeRegist/ChallengeDetailModal.tsx
+++ b/frontend/src/components/challengeRegist/ChallengeDetailModal.tsx
@@ -201,7 +201,7 @@ export default function ChallengeDetailModal({
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="비밀번호 입력"
+              placeholder="비밀번호 입력(ex: 1234)"
               className="focus:border-primary-purple-100 border-input-gray bg-input-gray h-10 flex-1 rounded-md border px-3 py-2 text-sm text-white placeholder-gray-400 focus:outline-none"
             />
           )}

--- a/frontend/src/components/feedCheck/ChallengeFeedCheck.tsx
+++ b/frontend/src/components/feedCheck/ChallengeFeedCheck.tsx
@@ -24,6 +24,7 @@ function ChallengeFeedCheck() {
   const { mutate: evaluateFeed, status: patchStatus } = useEvaluateFeed();
 
   useEffect(() => {
+    // PENDING
     if (selectedFeed) {
       setLocalStatus(selectedFeed.checkStatus);
     }
@@ -104,13 +105,14 @@ function ChallengeFeedCheck() {
                   }
                   className="focus:border-primary-purple-200 w-32 rounded-lg border border-gray-700 bg-[#2A2A2D] px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none"
                 >
+                  <option value="PENDING">대기</option>
                   <option value="APPROVED">승인</option>
                   <option value="REJECTED">거절</option>
                 </select>
                 <button
                   onClick={handleConfirm}
                   disabled={patchStatus === "pending"}
-                  className="bg-primary-purple-200 ml-2 cursor-pointer rounded-lg px-4 py-2 text-sm font-semibold text-white hover:opacity-90 disabled:opacity-50"
+                  className="bg-primary-purple-200 ml-2 w-20 cursor-pointer rounded-lg px-4 py-2 text-sm font-semibold text-white hover:opacity-90 disabled:opacity-50"
                 >
                   {patchStatus === "pending" ? "처리중…" : "확인"}
                 </button>


### PR DESCRIPTION
## 개요

Resolves: 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용

- 사용자에게 혼란을 줄 수 있는 챌린지 디테일 페이지 안내 문구 수정 
- 미구현 기능 hover 효과 삭제 (이유 상기와 동일)
- 비밀 방 참여 모달 input placeholder에 1234 입력 예시 추가
- 결제 미승인 오류-> mapper existsByPaymentKey parameterType이 string으로 기재된 오류 (대소문자 이슈) 수정 
- 챌린지 룸 이동시 active tab 기본이 feed가 되도록 수정 
- 대기상태의 피드인 경우 승인 체크가 바로 이루어지지 않는 오류 수정 (기존 ui에서는 pending없이 approved, rejected만 표기하였으나, 오류 수정과 더불어 챌린지 매니저가 명시적으로 피드를 보류 상태로 이관할 필요성도 있다고 판단하여 추가)

## 스크린샷

![feedCheck](https://github.com/user-attachments/assets/6559ffe7-3beb-41e0-8147-29e57778ed24)

