### PR TITLE
refactor: 결제 보상 흐름 책임 통합 및 재시도 큐 연결

### DIFF
--- a/backend/demo/src/main/java/store/oneul/mvc/payment/dto/CompensationResultDTO.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/dto/CompensationResultDTO.java
@@ -1,0 +1,34 @@
+package store.oneul.mvc.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CompensationResultDTO {
+
+    private final boolean refunded;
+    private final boolean pending;
+    private final int refundAmount;
+    private final String refundedAt;
+
+    public static CompensationResultDTO refunded(int refundAmount, String refundedAt) {
+        return CompensationResultDTO.builder()
+                .refunded(true)
+                .pending(false)
+                .refundAmount(refundAmount)
+                .refundedAt(refundedAt)
+                .build();
+    }
+
+    public static CompensationResultDTO pending() {
+        return CompensationResultDTO.builder()
+                .refunded(false)
+                .pending(true)
+                .refundAmount(0)
+                .refundedAt(null)
+                .build();
+    }
+}

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/event/CompensationEventHandler.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/event/CompensationEventHandler.java
@@ -17,7 +17,7 @@ public class CompensationEventHandler {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
     public void onRollback(PaymentConfirmedEvent event) {
-        log.warn("🌀 트랜잭션 롤백 감지 - Toss 결제 취소 시도");
-        compensationService.handleConfirmFail(event);
+        log.warn("트랜잭션 롤백 감지 - Toss 결제 취소 시도");
+        compensationService.compensate(event);
     }
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/CompensationService.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/CompensationService.java
@@ -1,8 +1,9 @@
 package store.oneul.mvc.payment.service;
 
+import store.oneul.mvc.payment.dto.CompensationResultDTO;
 import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
 
 public interface CompensationService {
 
-    void handleConfirmFail(PaymentConfirmedEvent event);  // 결제 실패 시 보상 처리
+    CompensationResultDTO compensate(PaymentConfirmedEvent event);  // 결제 실패 시 보상 처리
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/service/CompensationServiceImpl.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/service/CompensationServiceImpl.java
@@ -1,9 +1,12 @@
 package store.oneul.mvc.payment.service;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import store.oneul.mvc.payment.dto.CompensationResultDTO;
 import store.oneul.mvc.payment.enums.RefundReason;
 import store.oneul.mvc.payment.event.PaymentConfirmedEvent;
 
@@ -15,21 +18,32 @@ public class CompensationServiceImpl implements CompensationService {
     private final TossCancelService tossCancelService;
     private final RefundReceiptService refundReceiptService;
     private final CancelDLQService cancelDLQService;
-    
+
     @Override
-    public void handleConfirmFail(PaymentConfirmedEvent event) {
+    public CompensationResultDTO compensate(PaymentConfirmedEvent event) {
         try {
-            log.warn("보상 트랜잭션 시작 - Toss Cancel 요청");
+            log.warn("보상 트랜잭션 시작 - Toss Cancel 요청, orderId: {}", event.getOrderId());
 
             int refundAmount = tossCancelService.cancel(event, RefundReason.TX_FAIL);
 
-            // db 저장 실패로 인한 환불
-            refundReceiptService.recordAutoRefund(event, refundAmount, "DB 저장 실패로 인한 자동 환불");
+            String refundedAt = LocalDateTime.now().toString();
+
+            refundReceiptService.recordAutoRefund(
+                    event,
+                    refundAmount,
+                    "DB 저장 실패로 인한 자동 환불"
+            );
+
+            log.info("보상 트랜잭션 성공 - 자동 환불 완료, orderId: {}", event.getOrderId());
+
+            return CompensationResultDTO.refunded(refundAmount, refundedAt);
 
         } catch (Exception e) {
-            log.error("❌ Toss Cancel 실패 - DLQ 적재 예정", e);
-            // TODO: Redis DLQ 적재
+            log.error("Toss Cancel 또는 환불 기록 실패 - Redis Queue 적재, orderId: {}", event.getOrderId(), e);
+
             cancelDLQService.pushToQueue(event);
+
+            return CompensationResultDTO.pending();
         }
     }
 }

--- a/backend/demo/src/main/java/store/oneul/mvc/payment/usecase/PaymentUsecase.java
+++ b/backend/demo/src/main/java/store/oneul/mvc/payment/usecase/PaymentUsecase.java
@@ -15,6 +15,8 @@ import store.oneul.mvc.payment.service.RefundReceiptService;
 import store.oneul.mvc.payment.service.TossCancelService;
 import store.oneul.mvc.payment.service.TossConfirmService;
 import store.oneul.mvc.payment.validator.PaymentValidator;
+import store.oneul.mvc.payment.dto.CompensationResultDTO;
+import store.oneul.mvc.payment.service.CompensationService;
 
 @Slf4j
 @Service
@@ -24,8 +26,8 @@ public class PaymentUsecase {
     private final PaymentValidator paymentValidator;
     private final TossConfirmService tossConfirmService;
     private final PaymentSaveService paymentSaveService;
-    private final TossCancelService tossCancelService;
-    private final RefundReceiptService refundReceiptService;
+    private final CompensationService compensationService;
+
 
     public PaymentResultResponse confirmPayment(Long userId, PaymentConfirmRequest request) {
 
@@ -52,26 +54,24 @@ public class PaymentUsecase {
             return PaymentResultResponse.success(tossResponse);
 
         } catch (Exception e) {
-            log.error("❌ 결제 저장 실패 → TossCancel 보상 처리 진입", e);
+            log.error("결제 저장 실패 → 보상 트랜잭션 진입, orderId: {}", tossResponse.getOrderId(), e);
 
-            try {
-                // 6. Toss 결제 취소
-                int refundAmount = tossCancelService.cancel(event, RefundReason.TX_FAIL);
+            // 6. 보상 흐름은 CompensationService가 담당
+            CompensationResultDTO compensationResult = compensationService.compensate(event);
 
-                // 7. 환불 내역 저장 (환불 시각은 지금 시간 기준)
-                String refundedAt = java.time.LocalDateTime.now().toString(); // ISO 8601 포맷
 
-                refundReceiptService.recordAutoRefund(event, refundAmount, "결제 저장 실패에 따른 자동 환불");
-
-                // 8. 응답 반환
-                return PaymentResultResponse.refunded(tossResponse, refundAmount, refundedAt);
-
-            } catch (Exception ex) {
-                log.error("❌ TossCancel 또는 환불기록 실패 → 수동 환불 전환 필요", ex);
-
-                // 9. 수동 환불 응답 반환
-                return PaymentResultResponse.refundPending(tossResponse);
+            // 7. Toss Cancel 성공
+            if (compensationResult.isRefunded()) {
+                return PaymentResultResponse.refunded(
+                        tossResponse,
+                        compensationResult.getRefundAmount(),
+                        compensationResult.getRefundedAt()
+                );
             }
+
+            // 8. Toss Cancel 실패 → Redis Queue 적재 후 환불 대기 응답
+            return PaymentResultResponse.refundPending(tossResponse);
         }
+
     }
 }


### PR DESCRIPTION
## 개요

Resolves: #

결제 저장 실패 이후의 보상 처리 책임을 `CompensationService` 중심으로 정리하고, Toss Cancel 실패 시 Redis Queue 재시도 흐름으로 이어지도록 개선했습니다.

## PR 유형

어떤 변경 사항이 있나요?

- [x] 코드 리팩토링

## 작업 내용

- `PaymentUsecase`에서 직접 처리하던 Toss Cancel 및 환불 기록 로직을 제거했습니다.
- 결제 저장 실패 이후의 보상 처리를 `CompensationService.compensate()`로 위임하도록 수정했습니다.
- `CompensationService`가 Toss Cancel 성공/실패 결과를 반환할 수 있도록 `CompensationResult`를 추가했습니다.
- Toss Cancel 성공 시 자동 환불 기록 후 환불 완료 응답으로 이어지도록 정리했습니다.
- Toss Cancel 실패 시 `CancelDLQService.pushToQueue()`를 호출해 Redis Queue 기반 재시도 흐름으로 연결되도록 수정했습니다.
- 기존 `handleConfirmFail` 메서드명을 제거하고, 보상 처리 메서드명을 `compensate`로 통일했습니다.

## 스크린샷

해당 PR은 결제 실패 보상 흐름 리팩토링 작업으로, 별도 UI 변경사항은 없습니다.

## 공유사항 to 리뷰어

- 기존에는 `PaymentUsecase`가 Toss Cancel과 환불 기록까지 직접 처리하고 있어 결제 승인 흐름과 보상 처리 책임이 섞여 있었습니다.
- 이번 변경에서는 `PaymentUsecase`는 결제 승인 및 DB 저장 흐름만 조율하고, DB 저장 실패 이후 보상 처리는 `CompensationService`에서 담당하도록 분리했습니다.
- Toss Cancel 실패 시 Redis Queue에 적재되어 기존 재시도 스케줄러 흐름으로 이어질 수 있도록 연결했습니다.
- `CompensationEventHandler`는 기존 보상 처리 흔적이 남아 있어 컴파일 오류가 나지 않도록 메서드명만 맞췄습니다. 다만 현재 메인 보상 흐름은 `PaymentUsecase → CompensationService` 구조입니다.
- 리뷰 시 아래 흐름을 중점적으로 확인 부탁드립니다.

```txt
Toss Confirm 성공
→ PaymentSaveService.save()
→ DB 저장 실패
→ CompensationService.compensate()
→ Toss Cancel 시도
→ 성공: 환불 기록 후 ROLLBACK_REFUNDED 응답
→ 실패: Redis Queue 적재 후 ROLLBACK_PENDING 응답

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refund status tracking with refunded/pending states and timestamps for payment compensation operations.

* **Refactor**
  * Refactored payment compensation flow to use a dedicated service, improving error handling and state management for failed payments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/today-is-first/oneul/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->